### PR TITLE
Use a ColumnBuilder abstraction & a Trie

### DIFF
--- a/Sources/Penguin/CSVParsible.swift
+++ b/Sources/Penguin/CSVParsible.swift
@@ -61,6 +61,7 @@ extension Int: PCSVParsible {
 			var sign = 1
 			var base = 0
 			var i = 0
+			var hasNumber = false
 
 			// Skip leading whitespace.
 			while Unicode.Scalar(buf[i]) == " " && i < buf.count {
@@ -82,9 +83,11 @@ extension Int: PCSVParsible {
 				if elem < 0 || elem > 9 {
 					break
 				}
+				hasNumber = true
 				base = base * 10 + Int(elem)
 				i += 1
 			}
+			if !hasNumber { return nil }
 			self = sign * base
 		}
 	}

--- a/Sources/Penguin/TableCSV.swift
+++ b/Sources/Penguin/TableCSV.swift
@@ -248,7 +248,7 @@ struct BooleanColumnBuilder: ColumnBuilder {
                 let charR = Unicode.Scalar(buf[i + 1])
                 let charU = Unicode.Scalar(buf[i + 2])
                 let charE = Unicode.Scalar(buf[i + 3])
-                if (charR == "r" || charR == "R") && 
+                if (charR == "r" || charR == "R") &&
                    (charU == "u" || charU == "U") &&
                    (charE == "e" || charE == "E") {
                     append(true)

--- a/Sources/Penguin/TableCSV.swift
+++ b/Sources/Penguin/TableCSV.swift
@@ -78,7 +78,7 @@ extension PTable {
 /// ColumnBuilder allows for efficient appending to (untyped) columns.
 ///
 /// After creating a ColumnBuilder, append a few thousand entries into the
-/// builder, and then call `optimize`, which will return a new ColumnBuilder
+/// builder, and then call `optimized`, which will return a new ColumnBuilder
 /// which can be used to continue appending. When file processing is complete,
 /// call `finish` to get the built `PColumn`.
 ///

--- a/Sources/Penguin/TableCSV.swift
+++ b/Sources/Penguin/TableCSV.swift
@@ -45,6 +45,10 @@ extension PTable {
         var columns = reader.metadata.columns.map { $0.makeColumn() }
 
         try reader.forEach { (row, i) in
+            // After 1k rows, see if we can optimize ourselves a bit...
+            if i == 1000 {
+                columns = columns.map { $0.optimized() }
+            }
             if row.count > columnNames.count {
                 print("""
                     Encountered extra column(s) at row \(i); \
@@ -65,22 +69,262 @@ extension PTable {
             }
         }
 
-        self.columnMapping = Dictionary(uniqueKeysWithValues: zip(columnNames, columns))
+        self.columnMapping = Dictionary(uniqueKeysWithValues: zip(
+            columnNames, columns.map { $0.finish() }))
         self.columnOrder = columnNames
     }
 }
 
+/// ColumnBuilder allows for efficient appending to (untyped) columns.
+///
+/// After creating a ColumnBuilder, append a few thousand entries into the
+/// builder, and then call `optimize`, which will return a new ColumnBuilder
+/// which can be used to continue appending. When file processing is complete,
+/// call `finish` to get the built `PColumn`.
+///
+/// This design allows for more efficient parsing, and reduces virtual function
+/// dispatch overhead.
+protocol ColumnBuilder {
+    mutating func append(_ cell: CSVCell)
+    mutating func appendNil()
+
+    func optimized() -> ColumnBuilder
+
+    func finish() -> PColumn
+}
+
+struct NumericColumnBuilder<T: Numeric & ElementRequirements>: ColumnBuilder {
+    mutating func append(_ cell: CSVCell) {
+        guard let tmp = T(cell) else {
+            appendNil()
+            return
+        }
+        elements.append(tmp)
+        nils.append(false)
+    }
+
+    mutating func appendNil() {
+        elements.append(T())
+        nils.append(true)
+    }
+
+    func optimized() -> ColumnBuilder { self }  // No optimizations.
+
+    func finish() -> PColumn {
+        let typedColumn = PTypedColumn(elements, nils: nils)
+        return PColumn(typedColumn)
+    }
+
+    private var elements = [T]()
+    private var nils = PIndexSet(empty: true)
+}
+
+/// BasicStringColumnBuilder does nothing fancy during append operations,
+/// and simply adds strings to an array.
+struct BasicStringColumnBuilder: ColumnBuilder {
+    mutating func append(_ cell: CSVCell) {
+        guard let tmp = String(cell) else {
+            appendNil()
+            return
+        }
+        elements.append(tmp)
+        nils.append(false)
+    }
+
+    mutating func appendNil() {
+        elements.append("")
+        nils.append(true)
+    }
+
+    func optimized() -> ColumnBuilder {
+        let subset = elements[0..<1000]
+        if Set(subset).count < (subset.count / 2) {
+            return SmallSetStringColumnBuilder(elements: elements, nils: nils)
+        }
+        return self
+    }
+
+    func finish() -> PColumn {
+        return PColumn(PTypedColumn(elements, nils: nils))
+    }
+
+    private var elements = [String]()
+    private var nils = PIndexSet(empty: true)
+}
+
+struct SmallSetStringColumnBuilder: ColumnBuilder {
+    init() {
+        self.nils = PIndexSet(empty: true)
+    }
+
+    init(elements: [String], nils: PIndexSet) {
+        self.nils = nils
+        handles.reserveCapacity(elements.count)
+        for elem in elements {
+            let handle = encoder[encode: elem]
+            trie[elem] = handle
+            handles.append(handle)
+        }
+    }
+
+    mutating func append(_ cell: CSVCell) {
+        switch cell {
+        case .empty:
+            appendNil()
+            return
+        case let .raw(buf):
+            if let handle = trie[buf] {
+                handles.append(handle)
+                nils.append(false)
+                return
+            }
+            guard let str = String(cell) else {
+                handles.append(.nilHandle)
+                nils.append(true)
+                return
+            }
+            let handle = encoder[encode: str]
+            trie[buf] = handle
+            handles.append(handle)
+            nils.append(false)
+        case let .escaped(str):
+            let handle = encoder[encode: str]
+            handles.append(handle)
+            nils.append(false)
+        }
+    }
+
+    mutating func appendNil() {
+        handles.append(EncodedHandle.nilHandle)
+        nils.append(true)
+    }
+
+    func optimized() -> ColumnBuilder { self }
+    func finish() -> PColumn {
+        PColumn(PTypedColumn(impl: PTypedColumnImpl.encoded(encoder, handles),
+                             nils: nils))
+    }
+
+    // We use the trie to avoid paying the utf8 verification cost.
+    var trie = Trie<EncodedHandle>()
+    var encoder = Encoder<String>()
+    var handles = [EncodedHandle]()
+    var nils: PIndexSet
+}
+
+struct BooleanColumnBuilder: ColumnBuilder {
+    mutating func append(_ cell: CSVCell) {
+        switch cell {
+        case .empty:
+            appendNil()
+            return
+        case let .raw(buf):
+            guard buf.count > 0 else {
+                appendNil()
+                return
+            }
+            var i = 0
+            // Ignore early whitespace.
+            while i < buf.count {
+                if Unicode.Scalar(buf[i]) != " " { break }
+                i += 1
+            }
+            switch Unicode.Scalar(buf[i]) {
+            case "0", "1":
+                if buf.count == i + 1 || Unicode.Scalar(buf[i + 1]) == " " {
+                    append(Unicode.Scalar(buf[i]) != "0")
+                    return
+                }
+            case "T", "t":
+                if buf.count == i + 1 {
+                    append(true)
+                    return
+                }
+                if buf.count <= i + 3 {
+                    // Too short!
+                    appendNil()
+                    return
+                }
+                let charR = Unicode.Scalar(buf[i + 1])
+                let charU = Unicode.Scalar(buf[i + 2])
+                let charE = Unicode.Scalar(buf[i + 3])
+                if (charR == "r" || charR == "R") && 
+                   (charU == "u" || charU == "U") &&
+                   (charE == "e" || charE == "E") {
+                    append(true)
+                    return
+                }
+                appendNil()
+                return
+            case "F", "f":
+                if buf.count == i + 1 {
+                    append(false)
+                    return
+                }
+                if buf.count <= i + 4 {
+                    // Too Short!
+                    appendNil()
+                    return
+                }
+                let charA = Unicode.Scalar(buf[i + 1])
+                let charL = Unicode.Scalar(buf[i + 2])
+                let charS = Unicode.Scalar(buf[i + 3])
+                let charE = Unicode.Scalar(buf[i + 4])
+                if (charA == "a" || charA == "A") &&
+                   (charL == "l" || charL == "L") &&
+                   (charS == "s" || charS == "S") &&
+                   (charE == "e" || charE == "E") {
+                    append(false)
+                    return
+                }
+                appendNil()
+                return
+            default:
+                appendNil()
+                return
+            }
+        case let .escaped(str):
+            // Slow path.
+            guard let parsed = Bool(parsing: str) else {
+                appendNil()
+                return
+            }
+            append(parsed)
+            return
+        }
+    }
+
+    private mutating func append(_ value: Bool) {
+        elements.append(value)
+        nils.append(false)
+    }
+
+    mutating func appendNil() {
+        elements.append(Bool())
+        nils.append(true)
+    }
+
+    func optimized() -> ColumnBuilder { self }
+    func finish() -> PColumn {
+        let typedColumn = PTypedColumn(elements, nils: nils)
+        return PColumn(typedColumn)
+    }
+
+    private var elements = [Bool]()
+    private var nils = PIndexSet(empty: true)
+}
+
 fileprivate extension CSVColumnMetadata {
-    func makeColumn() -> PColumn {
+    func makeColumn() -> ColumnBuilder {
         switch type {
         case .string:
-            return PColumn(empty: String.self)
+            return BasicStringColumnBuilder()
         case .int:
-            return PColumn(empty: Int.self)
+            return NumericColumnBuilder<Int>()
         case .double:
-            return PColumn(empty: Double.self)
+            return NumericColumnBuilder<Double>()
         case .bool:
-            return PColumn(empty: Bool.self)
+            return BooleanColumnBuilder()
         }
     }
 }

--- a/Sources/Penguin/Trie.swift
+++ b/Sources/Penguin/Trie.swift
@@ -1,0 +1,169 @@
+
+/// Trie implements a map from string prefixes (as sequences of [UInt8]) to
+/// integer values.
+///
+/// This implementation is hyper-optimized for CSV parsing in Penguin, and
+/// assumes a relatively sparse space.
+///
+/// This trie stores a mapping from `UnsafeBufferPointer<UInt8>`'s to `T`'s.
+struct Trie<T> {
+
+    /// NodeId refers to the index in the `nodes` array.
+    ///
+    /// When set to -1, it signifies that it is "unset".
+    typealias NodeId = Int32
+
+    /// The trie is flattened into a flat array of `Node`'s. The "pointers" of
+    /// the data structure (the `NodeId`'s) are simply indices into this array.
+    var nodes = [Node()]
+
+    init() {}
+
+    subscript(str: String) -> T? {
+        get {
+            var copy = str
+            return copy.withUTF8 {
+                self[$0]
+            }
+        }
+        set {
+            var copy = str
+            copy.withUTF8 {
+                self[$0] = newValue
+            }
+        }
+    }
+
+    subscript(buf: UnsafeBufferPointer<UInt8>) -> T? {
+        get {
+            var nodeIndex = 0
+            for char in buf {
+                guard let newNodeIndex = nodes[nodeIndex][char],
+                      newNodeIndex != -1 else { return nil }
+                nodeIndex = Int(newNodeIndex)
+            }
+            return nodes[nodeIndex].value
+        }
+        set {
+            var nodeIndex = 0
+            for char in buf {
+                if let newNodeIndex = nodes[nodeIndex][char], newNodeIndex != -1 {
+                    nodeIndex = Int(newNodeIndex)
+                    continue
+                }
+                // Add a new node.
+                nodes[nodeIndex][char] = Int32(nodes.count)
+                nodeIndex = nodes.count
+                nodes.append(Node())
+            }
+            precondition(nodes[nodeIndex].value == nil)
+            nodes[nodeIndex].value = newValue
+        }
+    }
+
+    struct Node {
+        var value: T?
+        var entries: NodeEntry?
+
+        subscript(char: UInt8) -> NodeId? {
+            get {
+                if let entries = entries {
+                    return entries[char]
+                }
+                return nil
+            }
+            set {
+                precondition(newValue != nil, "Cannot set nil value at \(char); self: \(self)")
+                guard entries != nil else {
+                    self.entries = NodeEntry(char: char, nodeId: newValue!)
+                    return
+                }
+                self.entries![char] = newValue
+            }
+        }
+    }
+
+
+    enum NodeEntry {
+        case inline(chars: SIMD8<UInt8>, indices: SIMD8<NodeId>)
+        case outOfLine(references: [(UInt8, NodeId)])
+
+        init(char: UInt8, nodeId: NodeId) {
+            var chars = SIMD8<UInt8>(repeating: 0)
+            chars[0] = char
+            var indices = SIMD8<Int32>(repeating: -1)
+            indices[0] = nodeId
+            self = .inline(chars: chars, indices: indices)
+        }
+
+        subscript(char: UInt8) -> NodeId? {
+            get {
+                switch self {
+                case let .inline(chars, indices):
+                    // Vectorized implementation of a linear search.
+                    let bools = chars .!= char
+                    if bools != SIMDMask(repeating: true) {
+                        assert((~bools._storage).wrappedSum() == -1, "\(self), \(char), \(bools)")
+                        // We have a match!
+                        // We must fiddle with the types now a bit.
+                        let int32MaskStorage: SIMD8<Int32> = SIMD8(truncatingIfNeeded: bools._storage)
+                        let mask = SIMDMask(int32MaskStorage)
+                        // Futz with the types.
+                        return indices.replacing(with: 0, where: mask).wrappedSum()
+                    }
+                    return nil
+                case let .outOfLine(references):
+                    // TODO: profile to compare binary search vs linear scan.
+                    for i in references {
+                        if i.0 == char {
+                            return i.1
+                        }
+                    }
+                    return nil
+                }
+            }
+            set {
+                // Once a value has been set, it should never change!
+                assert(self[char] == nil, "self: \(self), char: \(char)")
+                assert(newValue != nil, "Cannot set \(char) to nil; \(self)")
+                // Use this silly pattern to avoid being accidentally quadratic.
+                if case var .inline(chars, indices) = self {
+                    assert(chars.scalarCount == indices.scalarCount)
+                    for i in 0..<chars.scalarCount {
+                        if chars[i] == 0 && indices[i] == -1 {
+                            chars[i] = char
+                            indices[i] = newValue!
+                            self = .inline(chars: chars, indices: indices)
+                            return
+                        }
+                    }
+                    // Convert to out-of-line representation.
+                    var outOfLineRepresentation = [(UInt8, NodeId)]()
+                    outOfLineRepresentation.reserveCapacity(9)
+                    for i in 0..<chars.scalarCount {
+                        outOfLineRepresentation.append((chars[i], indices[i]))
+                    }
+                    outOfLineRepresentation.append((char, newValue!))
+                    self = .outOfLine(references: outOfLineRepresentation)
+                }
+                if case var .outOfLine(references) = self {
+                    // Overwrite self!
+                    self = .inline(chars: SIMD8(repeating: 0), indices: SIMD8(repeating: 0))
+                    // Now append.
+                    references.append((char, newValue!))
+                    // Reset self.
+                    self = .outOfLine(references: references)
+                    return
+                }
+                fatalError("Unimplemented case in set!")
+            }
+        }
+
+        var isInline: Bool {
+            switch self {
+            case .inline: return true
+            case .outOfLine: return false
+            }
+        }
+    }
+}

--- a/Sources/Penguin/Trie.swift
+++ b/Sources/Penguin/Trie.swift
@@ -56,7 +56,6 @@ struct Trie<T> {
                 nodeIndex = nodes.count
                 nodes.append(Node())
             }
-            precondition(nodes[nodeIndex].value == nil)
             nodes[nodeIndex].value = newValue
         }
     }

--- a/Sources/Penguin/Trie.swift
+++ b/Sources/Penguin/Trie.swift
@@ -1,3 +1,16 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /// Trie implements a map from string prefixes (as sequences of [UInt8]) to
 /// integer values.

--- a/Sources/Penguin/TypedColumn.swift
+++ b/Sources/Penguin/TypedColumn.swift
@@ -53,6 +53,11 @@ public struct PTypedColumn<T: ElementRequirements>: Equatable {
         self.nils = PIndexSet(all: false, count: 0)
     }
 
+    init(impl: PTypedColumnImpl<T>, nils: PIndexSet) {
+        self.impl = impl
+        self.nils = nils
+    }
+
     public func map<U>(_ transform: (T) throws -> U) rethrows -> PTypedColumn<U> {
         var newImpl = [U]()
         newImpl.reserveCapacity(impl.count)
@@ -563,6 +568,10 @@ extension PTypedColumnImpl: Collection {
 /// Represents an encoded value
 struct EncodedHandle: Equatable, Hashable {
     var value: UInt32
+
+    static var nilHandle: EncodedHandle {
+        EncodedHandle(value: UInt32.max)
+    }
 }
 
 /// Encodes hashable values T into a dense integer representation.

--- a/Tests/PenguinTests/CSVParsibleTests.swift
+++ b/Tests/PenguinTests/CSVParsibleTests.swift
@@ -18,14 +18,10 @@ import PenguinCSV
 
 final class CSVParsibleTests: XCTestCase {
 	func testIntParsing() throws {
-		print("one")
 		assertParse(" 1", as: 1)
 		assertParse("0", as: 0)
-		print("three")
 		assertParse(" 100 ", as: 100)
-		print("four")
 		assertParse(" -123", as: -123)
-		print("five")
 	}
 
 	static var allTests = [

--- a/Tests/PenguinTests/TableCSVTests.swift
+++ b/Tests/PenguinTests/TableCSVTests.swift
@@ -91,7 +91,27 @@ final class TableCSVTests: XCTestCase {
             nil,
         ]
         XCTAssertEqual(PColumn(expected), builder.finish())
+    }
 
+    func testSmallStringBuilder() {
+        let candidates = ["foo", "bar", "baz", "quux", "foobar", "asdf", "fdas"]
+        var elements = [String]()
+        elements.reserveCapacity(2050)
+        for _ in 0..<1050 {
+            elements.append(candidates.randomElement()!)
+        }
+        var builder = SmallSetStringColumnBuilder(
+            elements: elements,
+            nils: PIndexSet(all: false, count: 1050))
+
+        for _ in 0..<1000 {
+            let choice = candidates.randomElement()!
+            elements.append(choice)
+            builder.testAppend(choice)
+        }
+
+        let expected = PColumn(elements, nils: PIndexSet(all: false, count: 2050))
+        XCTAssertEqual(expected, builder.finish())
     }
 
     func testSimpleParse() throws {
@@ -127,6 +147,7 @@ final class TableCSVTests: XCTestCase {
         ("testBooleanBuilder", testBooleanBuilder),
         ("testIntBuilder", testIntBuilder),
         ("testBasicStringBuilder", testBasicStringBuilder),
+        ("testSmallStringBuilder", testSmallStringBuilder),
         ("testSimpleParse", testSimpleParse),
         ("testTsvParseWithTrailingNewline", testTsvParseWithTrailingNewline)
     ]
@@ -145,6 +166,12 @@ fileprivate extension NumericColumnBuilder {
 }
 
 fileprivate extension BasicStringColumnBuilder {
+    mutating func testAppend(_ testValue: String) {
+        testBuilderRawParsing(&self, cell: testValue)
+    }
+}
+
+fileprivate extension SmallSetStringColumnBuilder {
     mutating func testAppend(_ testValue: String) {
         testBuilderRawParsing(&self, cell: testValue)
     }

--- a/Tests/PenguinTests/TableCSVTests.swift
+++ b/Tests/PenguinTests/TableCSVTests.swift
@@ -14,18 +14,96 @@
 
 import XCTest
 @testable import Penguin
+import PenguinCSV
 
 final class TableCSVTests: XCTestCase {
+
+    func testBooleanBuilder() {
+        var builder = BooleanColumnBuilder()
+        builder.testAppend("t")
+        builder.testAppend("T")
+        builder.testAppend("f")
+        builder.testAppend("F")
+        builder.testAppend(" t")
+        builder.testAppend("  F")
+        builder.testAppend(" TrUe ")
+        builder.testAppend(" false ")
+        builder.testAppend(" Foo")
+        builder.testAppend(" Tralmost!")
+        builder.testAppend("tru")
+        builder.testAppend(". random")
+        builder.testAppend("fals")
+        builder.testAppend("")
+        builder.testAppend("0")
+        builder.testAppend("  1")
+        let expected = [
+            true,
+            true,
+            false,
+            false,
+            true,
+            false,
+            true,
+            false,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            nil,
+            false,
+            true,
+        ]
+        XCTAssertEqual(PColumn(expected), builder.finish())
+    }
+
+    func testIntBuilder() {
+        var builder = NumericColumnBuilder<Int>()
+        builder.testAppend(" 1")
+        builder.testAppend(" 100 ")
+        builder.testAppend("0")
+        builder.testAppend("3")
+        builder.testAppend(" 6")
+        builder.testAppend(" false")
+        builder.testAppend(" -103")
+
+        let expected = [1, 100, 0, 3, 6, nil, -103]
+        XCTAssertEqual(PColumn(expected), builder.finish())
+    }
+
+    func testBasicStringBuilder() {
+        var builder = BasicStringColumnBuilder()
+        builder.testAppend("foo")
+        builder.testAppend("bar")
+        builder.testAppend("foo")
+        builder.testAppend("baz")
+        builder.testAppend("foo")
+        builder.testAppend("quux")
+        builder.appendNil()
+
+        let expected = [
+            "foo",
+            "bar",
+            "foo",
+            "baz",
+            "foo",
+            "quux",
+            nil,
+        ]
+        XCTAssertEqual(PColumn(expected), builder.finish())
+
+    }
+
     func testSimpleParse() throws {
         let table = try PTable(csvContents: """
             a,b,c,d
-            asdf,1,2,3.1
-            fdsa,4,5,6.2
+            asdf,1,f,3.1
+            fdsa,4,t,6.2
             """)
 
         let colA = PColumn(["asdf", "fdsa"])
         let colB = PColumn([1, 4])
-        let colC = PColumn([2, 5])
+        let colC = PColumn([false, true])
         let colD = PColumn([3.1, 6.2])
         let expected = try! PTable([("a", colA), ("b", colB), ("c", colC), ("d", colD)])
         XCTAssertEqual(expected, table)
@@ -46,7 +124,39 @@ final class TableCSVTests: XCTestCase {
     }
 
     static var allTests = [
+        ("testBooleanBuilder", testBooleanBuilder),
+        ("testIntBuilder", testIntBuilder),
+        ("testBasicStringBuilder", testBasicStringBuilder),
         ("testSimpleParse", testSimpleParse),
         ("testTsvParseWithTrailingNewline", testTsvParseWithTrailingNewline)
     ]
+}
+
+fileprivate extension BooleanColumnBuilder {
+    mutating func testAppend(_ testValue: String) {
+        testBuilderRawParsing(&self, cell: testValue)
+    }
+}
+
+fileprivate extension NumericColumnBuilder {
+    mutating func testAppend(_ testValue: String) {
+        testBuilderRawParsing(&self, cell: testValue)
+    }
+}
+
+fileprivate extension BasicStringColumnBuilder {
+    mutating func testAppend(_ testValue: String) {
+        testBuilderRawParsing(&self, cell: testValue)
+    }
+}
+
+fileprivate func testBuilderRawParsing<Builder: ColumnBuilder>(
+    _ builder: inout Builder,
+    cell: String
+) {
+    var copy = cell
+    copy.withUTF8 {
+        let cell = CSVCell.raw($0)
+        builder.append(cell)
+    }
 }

--- a/Tests/PenguinTests/TrieTests.swift
+++ b/Tests/PenguinTests/TrieTests.swift
@@ -13,21 +13,22 @@
 // limitations under the License.
 
 import XCTest
+@testable import Penguin
 
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(BoolComparableTests.allTests),
-        testCase(CSVParsibleTests.allTests),
-        testCase(ColumnTests.allTests),
-        testCase(IndexSetTests.allTests),
-        testCase(PenguinTests.allTests),
-        testCase(StringParsibleTests.allTests),
-        testCase(SummaryTests.allTests),
-        testCase(TableCSVTests.allTests),
-        testCase(TableTests.allTests),
-        testCase(TrieTests.allTests),
-        testCase(TypedColumnTests.allTests),
-    ]
+final class TrieTests: XCTestCase {
+
+	func testSimpleTrie() throws {
+		var trie = Trie<Int>()
+		trie["a"] = 1
+		trie["b"] = 2
+		trie["ab"] = 3
+		XCTAssertEqual(1, trie["a"])
+		XCTAssertEqual(2, trie["b"])
+		XCTAssertEqual(3, trie["ab"])
+		XCTAssertEqual(nil, trie["notThere"])
+	}
+
+	static var allTests = [
+		("testSimpleTrie", testSimpleTrie),
+	]
 }
-#endif


### PR DESCRIPTION
This PR introduces a `ColumnBuilder` abstraction which improves MovieLens parsing performance by 2x. The combination of `ColumnBuilder` and the `Trie` implementation results in a 3x performance improvement when parsing the criteo TSVs by avoiding unnecessary calls into Foundation.

Further, this PR also makes `PTypedColumn`'s compare semantically instead of comparing that the internal representations are the same. It also improves the correctness of number parsing in ints.