### PR TITLE
Add `storing:` label to `addVertex(_:)` for all `MutablePropertyGraph`s

### DIFF
--- a/Sources/PenguinGraphs/AdjacencyList.swift
+++ b/Sources/PenguinGraphs/AdjacencyList.swift
@@ -302,7 +302,7 @@ extension AdjacencyList: MutablePropertyGraph {
   /// Adds a new vertex with associated `vertexProperty`, returning its identifier.
   ///
   /// - Complexity: O(1) (amortized)
-  public mutating func addVertex(_ vertexProperty: Vertex) -> VertexId {
+  public mutating func addVertex(storing vertexProperty: Vertex) -> VertexId {
     let cnt = storage.count
     storage.append((vertexProperty, []))
     return VertexId(cnt)

--- a/Sources/PenguinGraphs/PropertyMaps.swift
+++ b/Sources/PenguinGraphs/PropertyMaps.swift
@@ -118,7 +118,7 @@ public protocol MutablePropertyGraph: MutableGraph, PropertyGraph
 where Vertex: DefaultInitializable, Edge: DefaultInitializable {
 
   /// Adds a vertex to the graph.
-  mutating func addVertex(_ vertexProperty: Vertex) -> VertexId
+  mutating func addVertex(storing vertexProperty: Vertex) -> VertexId
 
   /// Adds an edge to the graph.
   mutating func addEdge(from source: VertexId, to destination: VertexId, storing edgeProperty: Edge)
@@ -128,7 +128,7 @@ where Vertex: DefaultInitializable, Edge: DefaultInitializable {
 extension MutablePropertyGraph {
   /// Adds a new vertex to the graph, with a default initialized `Vertex`.
   public mutating func addVertex() -> VertexId {
-    addVertex(Vertex())
+    addVertex(storing: Vertex())
   }
 
   /// Adds an edge from `source` to `destination` with a default initialized `Edge`.

--- a/Tests/PenguinGraphTests/AdjacencyListTests.swift
+++ b/Tests/PenguinGraphTests/AdjacencyListTests.swift
@@ -195,8 +195,8 @@ extension AdjacencyListTests {
     var g = PropertyGraph()
 
     let v0 = g.addVertex()  // Default init.
-    let v1 = g.addVertex(Vertex(name: "Alice"))
-    let v2 = g.addVertex(Vertex(name: "Bob"))
+    let v1 = g.addVertex(storing: Vertex(name: "Alice"))
+    let v2 = g.addVertex(storing: Vertex(name: "Bob"))
 
     _ = g.addEdge(from: v1, to: v2, storing: Edge(weight: 1))
     _ = g.addEdge(from: v2, to: v1, storing: Edge(weight: 1))

--- a/Tests/PenguinGraphTests/InternalPropertyMapTests.swift
+++ b/Tests/PenguinGraphTests/InternalPropertyMapTests.swift
@@ -40,8 +40,8 @@ final class InternalPropertyMapTests: XCTestCase {
 
   func testSimpleVertexProperty() {
     var g = Graph()
-    let v1 = g.addVertex(ColoredNode(.gray))
-    let v2 = g.addVertex(ColoredNode(.black))
+    let v1 = g.addVertex(storing: ColoredNode(.gray))
+    let v2 = g.addVertex(storing: ColoredNode(.black))
     let v3 = g.addVertex()
 
     let map = InternalVertexPropertyMap(\ColoredNode.color, on: g)

--- a/Tests/PenguinGraphTests/ParallelExpanderTests.swift
+++ b/Tests/PenguinGraphTests/ParallelExpanderTests.swift
@@ -25,9 +25,9 @@ final class ParallelExpanderTests: XCTestCase {
 
   func testSimple() {
     var g = Graph()
-    let v1 = g.addVertex(TestLabeledVertex(seedLabels: [1, 0, -1]))
+    let v1 = g.addVertex(storing: TestLabeledVertex(seedLabels: [1, 0, -1]))
     let v2 = g.addVertex()
-    let v3 = g.addVertex(TestLabeledVertex(seedLabels: [-1, 1, 0]))
+    let v3 = g.addVertex(storing: TestLabeledVertex(seedLabels: [-1, 1, 0]))
 
     let e1 = g.addEdge(from: v1, to: v2)
     let e2 = g.addEdge(from: v3, to: v2)

--- a/Tests/PenguinGraphTests/VertexParallelTests.swift
+++ b/Tests/PenguinGraphTests/VertexParallelTests.swift
@@ -337,7 +337,7 @@ extension VertexParallelTests {
     //  '--> v3 ---^
     var g = ReachableGraph()
 
-    let v0 = g.addVertex(TestReachableVertex(isReachable: true))
+    let v0 = g.addVertex(storing: TestReachableVertex(isReachable: true))
     let v1 = g.addVertex()
     let v2 = g.addVertex()
     let v3 = g.addVertex()


### PR DESCRIPTION
Follow-ups to https://github.com/saeta/penguin/pull/6