### PR TITLE
Simplify Property Map's

### DIFF
--- a/Sources/Benchmarks/AdjacencyList.swift
+++ b/Sources/Benchmarks/AdjacencyList.swift
@@ -177,9 +177,13 @@ let adjacencyList = BenchmarkSuite(name: "AdjacencyList") { suite in
   }
 }
 
-fileprivate struct ConstantEdgeProperty<Graph: GraphProtocol, Value>: GraphEdgePropertyMap {
+fileprivate struct ConstantEdgeProperty<Graph: GraphProtocol, Value>: ExternalPropertyMap {
+  typealias Key = Graph.EdgeId
   let value: Value
-  func get(_ g: Graph, _ edge: Graph.EdgeId) -> Value { value }
+  subscript(key: Key) -> Value {
+    get { value }
+    set { fatalError() }
+  }
 }
 
 fileprivate struct Counter<Graph: GraphProtocol> {

--- a/Sources/PenguinGraphs/ParallelExpander.swift
+++ b/Sources/PenguinGraphs/ParallelExpander.swift
@@ -255,7 +255,7 @@ extension ParallelGraph where Self: IncidenceGraph, Self.Vertex: LabeledVertex {
   /// Vertices with no incoming edges will be assigned a `totalIncomingEdgeWeight` of 0.
   public mutating func computeIncomingEdgeWeightSum<
     Mailboxes: MailboxesProtocol,
-    VertexSimilarities: GraphEdgePropertyMap
+    VertexSimilarities: PropertyMap
   >(
     using mailboxes: inout Mailboxes,
     _ vertexSimilarities: VertexSimilarities
@@ -264,6 +264,7 @@ extension ParallelGraph where Self: IncidenceGraph, Self.Vertex: LabeledVertex {
     Mailboxes.Mailbox.Graph == Self,
     Mailboxes.Mailbox.Message == IncomingEdgeWeightSumMessage,
     VertexSimilarities.Value == Float,
+    VertexSimilarities.Key == EdgeId,
     VertexSimilarities.Graph == Self
   {
     // Send
@@ -297,7 +298,7 @@ extension ParallelGraph where Self: IncidenceGraph, Self.Vertex: LabeledVertex {
   /// Semi-Supervised Learning Using Streaming Approximation. AISTATS, 2016.
   public mutating func propagateLabels<
     Mailboxes: MailboxesProtocol,
-    VertexSimilarities: GraphEdgePropertyMap
+    VertexSimilarities: PropertyMap
   >(
     m1: Float,
     m2: Float,
@@ -311,6 +312,7 @@ extension ParallelGraph where Self: IncidenceGraph, Self.Vertex: LabeledVertex {
     Mailboxes.Mailbox.Graph == Self,
     Mailboxes.Mailbox.Message == Self.Vertex.Labels,
     VertexSimilarities.Value == Float,
+    VertexSimilarities.Key == EdgeId,
     VertexSimilarities.Graph == Self
   {
     for stepNumber in 0..<maxStepCount {

--- a/Sources/PenguinGraphs/PropertyMaps.swift
+++ b/Sources/PenguinGraphs/PropertyMaps.swift
@@ -14,82 +14,49 @@
 
 import PenguinStructures
 
-/// Maps a `VertexId` from a Graph to a property of type `Value` associated with that `VertexId`.
+/// Abstracts over storage location for values associated with graphs.
 ///
-/// Many graph algorithms require information associated with each vertex. Examples include:
-///   - if a vertex is a "goal" vertex in a graph search
-///   - if a vertex has been explored yet during a graph search (e.g. color).
-///   - the "predecessor" of a vertex (e.g. in a search)
-///   - the "discovery time" of a vertex (e.g. in a search)
-///   - the rank of a vertex
+/// Graph algorithms often need to store data during the course of execution, such as vertex color
+/// (during search), or the costs of traversing an edge (e.g. Dijkstra's algorithm). While some
+/// graph types can store data within the graph structure itself. (e.g. `AdjacencyList` allows
+/// associating data with every vertex and edge.) Some graph data structures are not materialized
+/// whatsoever (e.g. the possible moves on a knight's tour on a chess board). Additionally, data is
+/// often needed only during the course of an algorithm, and is discarded afterwards. As a result,
+/// it would be inefficient to pay the cost of requiring every graph implementation to persist this
+/// transient state. Fortunately, property maps allow us to leverage "in-graph" storage when it
+/// is available, while also allowing data to be stored outside the graph when convenient as well,
+/// all behind a single abstraction. In short, thanks to the PropertyMap protocol, we can write an
+/// algorithm once using one or more PropertyMap's, and the algorithm can be re-used independent of
+/// whether the data is stored within the graph data structure or in a separate data structure.
 ///
-/// `GraphVertexPropertyMap` abstracts over different storage implementations of the associated data
-/// for each vertex. Some graph implementations may store the associated information within the
-/// Graph data structure itself. Other graph implementations may want to store the information in
-/// a separate data structure (e.g. temporary data used within a single graph algorithm).
-///
-/// - SeeAlso: `MutableGraphVertexPropertyMap`
-/// - SeeAlso: `GraphEdgePropertyMap`
-/// - SeeAlso: `InternalVertexPropertyMap`
-public protocol GraphVertexPropertyMap {
-  /// The Graph this PropertyMap operates on.
+/// - SeeAlso: `ExternalPropertyMap`
+public protocol PropertyMap {
   associatedtype Graph: GraphProtocol
-  /// The data associated with each vertex by this map.
+  associatedtype Key
   associatedtype Value
 
-  /// Retrieves the `Value` associated with vertex `vertex` in `graph`.
-  func get(_ graph: Graph, _ vertex: Graph.VertexId) -> Value
+  /// Get the `Value` associated with `key` in `graph`.
+  func get(_ key: Key, in graph: Graph) -> Value
+
+  // TODO: Consider splitting set out into a refinement protocol?
+
+  /// Sets the `Value` associated with `key` in `graph`.
+  mutating func set(_ key: Key, in graph: inout Graph, to newValue: Value)
 }
 
-/// Allows modifying the associated vertex data.
-///
-/// Some graph algorithms modify associated data during their execution. PropertyMaps that conform
-/// to this protocol allow the associated data to be modified using `set`.
-///
-/// Note: in order to support both "internal" and "external" backing data structures for the
-/// property map, we take `graph` as `inout`.
-public protocol MutableGraphVertexPropertyMap: GraphVertexPropertyMap {
-
-  /// Sets the property on `vertex` to `value`.
-  mutating func set(vertex: Graph.VertexId, in graph: inout Graph, to value: Value)
+/// External property maps store data outside the graph.
+public protocol ExternalPropertyMap: PropertyMap {
+  subscript(key: Key) -> Value { get set }
 }
 
-/// Maps an `EdgeId` from a Graph to a property of type `Value` associated with that `EdgeId`.
-///
-/// Many graph algorithms require information associated with each edge. Examples include:
-///   - Weight of an edge to determine the cost of traversing it (e.g. during Dijkstra search).
-///   - Capacity of an edge to determine the maximum amount of flow that can traverse an edge.
-///   - The `EdgeId` of the reverse edge.
-///
-/// `GraphEdgePropertyMap` abstracts over different storage implementations of the associated data
-/// for each edge. Some graph implementations may store the associated data within the graph data
-/// structure itself. Other graph implementations may want to store the information in a separate
-/// data structure (e.g. temporary data used within a single graph algorithm).
-///
-/// - SeeAlso: `MutableGraphEdgePropertyMap`
-/// - SeeAlso: `GraphVertexPropertyMap`
-/// - SeeAlso: `InternalEdgePropertyMap`
-public protocol GraphEdgePropertyMap {
-  /// The graph this PropertyMap operates on.
-  associatedtype Graph: GraphProtocol
-  /// The data associated with each edge by this map.
-  associatedtype Value
+extension ExternalPropertyMap {
+  public func get(_ key: Key, in graph: Graph) -> Value {
+    self[key]
+  }
 
-  /// Retrieves the `Value` associated with edge `edge` in `graph`.
-  func get(_ graph: Graph, _ edge: Graph.EdgeId) -> Value
-}
-
-/// Allows modifying the associated edge data.
-///
-/// Some graph algorithms modify associated data during their execution. PropertyMaps that conform
-/// to this protocol  allow the associated data to be modified using `set`.
-///
-/// Note: in order to support both "internal" and "external" backing data structures for the
-/// property map, we take `graph` as `inout`.
-public protocol MutableGraphEdgePropertyMap: GraphEdgePropertyMap {
-
-  /// Sets the property on `edge` to `value`.
-  mutating func set(edge: Graph.EdgeId, in graph: inout Graph, to value: Value)
+  public mutating func set(_ key: Key, in graph: inout Graph, to newValue: Value) {
+    self[key] = newValue
+  }
 }
 
 /// A `PropertyGraph` stores additional information along with the graph structure.
@@ -103,14 +70,8 @@ public protocol PropertyGraph: GraphProtocol {
   /// Access information associated with a given `VertexId`.
   subscript(vertex vertex: VertexId) -> Vertex { get set /* _modify */ }
 
-  /// Access a property related to a given vertex.
-  subscript<T>(vertex vertex: VertexId, keypath: KeyPath<Vertex, T>) -> T { get /* set _modify */ }
-
   /// Access information associated with a given `EdgeId`.
   subscript(edge edge: EdgeId) -> Edge { get set /* _modify */ }
-
-  /// Access a property for a given edge.
-  subscript<T>(edge edge: EdgeId, keypath: KeyPath<Edge, T>) -> T { get /* set _modify */ }
 }
 
 /// A `MutablePropertyGraph` keeps track of additional metadata for each vertex and edge.
@@ -137,200 +98,144 @@ extension MutablePropertyGraph {
   }
 }
 
-/// Defines a `GraphVertexPropertyMap` exposing properties stored in the vertex type of the graph.
-///
-/// Example: say we had a Vertex type defined as follows:
-///
-/// ```swift
-/// struct City {
-///   let name: String
-/// }
-///
-/// extension City {
-///   var isGoal: Bool { name == "Rome" }  // Do all roads lead to Rome?
-/// }
-/// ```
-///
-/// we could expose the `isGoal` property (e.g. which can be used to terminate a graph traversal)
-/// as follows:
-///
-/// ```swift
-/// var g: PropertyGraph = ...
-/// var goalMap = InternalVertexPropertyMap(\City.isGoal, on: g)
-/// ```
-public struct InternalVertexPropertyMap<
-  Graph: PropertyGraph,
-  Value,
-  Path: KeyPath<Graph.Vertex, Value>
->: GraphVertexPropertyMap {
+/// A `PropertyMap` over the vertices of `Graph`.
+public struct InternalVertexPropertyMap<Graph: PropertyGraph>: PropertyMap {
+  public typealias Key = Graph.VertexId
+  public typealias Value = Graph.Vertex
 
-  /// The KeyPath between the `Graph.Vertex` and the `Value` reterned by the property map.
-  public let keyPath: Path
+  /// Create an `InternalVertexPropertyMap` for `graph`.
+  public init(for graph: __shared Graph) {}
 
-  /// Create an `InternalVertexPropertyMap` for a given keyPath `Path`.
-  ///
-  /// If `Path` is a `WritableKeyPath`, then this also conforms to `MutableGraphVertexPropertyMap`.
-  public init(_ keyPath: Path, on graph: __shared Graph) {
-    self.keyPath = keyPath
-  }
-
-  /// Initialize an `InternalVertexPropertyMap` from the given key path.
-  public init(_ keyPath: Path) {
-    self.keyPath = keyPath
-  }
+  /// Creates an `InternalVertexPropertyMap`.
+  public init() {}
 
   /// Retrieves the property value from `graph` for `vertex`.
-  public func get(_ graph: Graph, _ vertex: Graph.VertexId) -> Value {
-    graph[vertex: vertex][keyPath: keyPath]
+  public func get(_ vertex: Graph.VertexId, in graph: Graph) -> Value {
+    graph[vertex: vertex]
+  }
+
+  public mutating func set(_ vertex: Graph.VertexId, in graph: inout Graph, to newValue: Value) {
+    graph[vertex: vertex] = newValue
   }
 }
 
-// extension InternalVertexPropertyMap: MutableGraphVertexPropertyMap where Path: WritableKeyPath<Graph.Vertex, Value> {
-//  /// Sets the property value for `vertex` within `graph`.
-//     public mutating func set(graph: inout Graph, vertex: Graph.VertexId, value: Value) {
-//         graph[vertex: vertex][keyPath: keyPath] = value
-//     }
-// }
+/// A `PropertyMap` over the edges of `Graph`.
+public struct InternalEdgePropertyMap<Graph: PropertyGraph>: PropertyMap {
+  public typealias Key = Graph.EdgeId
+  public typealias Value = Graph.Edge
 
-/// Defines a `GraphEdgePropertyMap` exposing properties stored in the edge type of the graph.
-///
-/// Example: say we had an `Edge` type defined as follows:
-///
-/// ```swift
-/// struct WeightedEdge {
-///   var weight: Int
-/// }
-/// ```
-///
-/// we could expose the `weight` property (e.g. which can be used to evaluate the cost of traversing
-/// the edge) as follows:
-///
-/// ```swift
-/// var g: PropertyGraph = ...
-/// var weightMap = InternalEdgePropertyMap(\WeightedEdge.weight, on: g)
-/// ```
-///
-/// If you would like to initialize a map without an instance of a graph, you will need to spell out
-/// the types a bit more explicitly:
-///
-/// ```swift
-/// typealias Graph = PropertyAdjacencyList<VertexType, WeightedEdge, Int32>
-/// var weightMap = InternalEdgePropertyMap<Graph, Int, KeyPath<WeightedEdge, Int>(\WeightedEdge.weight)
-/// ```
-public struct InternalEdgePropertyMap<
-  Graph: PropertyGraph,
-  Value,
-  Path: KeyPath<Graph.Edge, Value>
->: GraphEdgePropertyMap {
+  /// Create an `InternalEdgePropertyMap` for `graph`.
+  public init(for graph: __shared Graph) {}
 
-  /// The KeyPath between `Graph.Edge` and `Value`.
-  public let keyPath: Path
+  /// Creates an `InternalEdgePropertyMap`.
+  public init() {}
 
-  /// Initialize an `InternalEdgePropertyMap` from the given `keyPath`.
-  ///
-  /// `graph` is taken as an additional argument to facilitate type inference.
-  public init(_ keyPath: Path, on graph: __shared Graph) {
-    self.keyPath = keyPath
+  /// Retrieves the property value from `graph` for `edge`.
+  public func get(_ edge: Graph.EdgeId, in graph: Graph) -> Value {
+    graph[edge: edge]
   }
 
-  /// Initialize an `InternalEdgePropertyMap` from the given `keyPath`.
-  public init(_ keyPath: Path) {
-    self.keyPath = keyPath
-  }
-
-  public func get(_ graph: Graph, _ edge: Graph.EdgeId) -> Value {
-    graph[edge: edge][keyPath: keyPath]
+  public mutating func set(_ edge: Graph.EdgeId, in graph: inout Graph, to newValue: Value) {
+    graph[edge: edge] = newValue
   }
 }
 
-// extension InternalEdgePropertyMap: MutableGraphEdgePropertyMap where Path: WritableKeyPath<Graph.Edge, Value> {
-//     public mutating func set(graph: inout Graph, edge: Graph.EdgeId, value: Value) {
-//         graph[edge: edge][keyPath: keyPath] = value
-//     }
-// }
+public struct TransformingPropertyMap<NewValue, Underlying: PropertyMap>: PropertyMap {
+  let keyPath: WritableKeyPath<Underlying.Value, NewValue>
+  var underlying: Underlying
 
-/// A table-based vertex property map.
-public struct TableVertexPropertyMap<Graph: GraphProtocol, Value>: GraphVertexPropertyMap,
-  MutableGraphVertexPropertyMap
-where Graph.VertexId: IdIndexable {
+  public func get(_ key: Underlying.Key, in graph: Underlying.Graph) -> NewValue {
+    return underlying.get(key, in: graph)[keyPath: keyPath]
+  }
+
+  public mutating func set(_ key: Underlying.Key, in graph: inout Underlying.Graph, to newValue: NewValue) {
+    // Future improvement: coroutines would be nice here. :-(
+    var tmp = underlying.get(key, in: graph)
+    tmp[keyPath: keyPath] = newValue
+    underlying.set(key, in: &graph, to: tmp)
+  }
+}
+
+extension PropertyMap {
+  public func transform<NewValue>(_ keyPath: WritableKeyPath<Value, NewValue>) -> TransformingPropertyMap<NewValue, Self> {
+    TransformingPropertyMap(keyPath: keyPath, underlying: self)
+  }
+}
+
+/// A table-based external property map.
+public struct TablePropertyMap<Graph: GraphProtocol, Key, Value>: ExternalPropertyMap
+where Key: IdIndexable {
   public var values: [Value]
 
-  /// Creates an instance where every vertex has value `initialValue`.
-  ///
-  /// Note: `count` must exactly equal `Graph.vertexCount`!
+  /// Creates an instance where every key has value `initialValue`.
   public init(repeating initialValue: Value, count: Int) {
     values = Array(repeating: initialValue, count: count)
   }
 
-  /// Creates an instance with `values`, indexed by the Graph's vertex indicies.
+  /// Creates an instance with `values`, indexed by `\Key.index`.
   public init(_ values: [Value]) {
     self.values = values
   }
 
-  /// Retrieves the `Value` associated with vertex `vertex` in `graph`.
-  public func get(_ graph: Graph, _ vertex: Graph.VertexId) -> Value {
-    values[vertex.index]
+  public subscript(key: Key) -> Value {
+    get { values[key.index] }
+    set { values[key.index] = newValue }
   }
-
-  /// Sets the property on `vertex` to `value`.
-  public mutating func set(vertex: Graph.VertexId, in graph: inout Graph, to value: Value) {
-    values[vertex.index] = value
-  }
-
 }
 
-extension TableVertexPropertyMap where Graph: VertexListGraph {
+extension TablePropertyMap where Graph: VertexListGraph, Graph.VertexId: IdIndexable, Key == Graph.VertexId {
+
   /// Creates an instance where every vertex has `initialValue` for use with `graph`.
   ///
   /// This initializer helps the type inference algorithm, obviating the need to spell out some of
   /// the types.
-  public init(repeating initialValue: Value, for graph: __shared Graph) {
+  public init(repeating initialValue: Value, forVerticesIn graph: __shared Graph) {
     self.init(repeating: initialValue, count: graph.vertexCount)
   }
 
   /// Creates an instance where the verticies have values `values`.
   ///
   /// This initializer helps the type inference algorithm, and does some consistency checking.
-  public init(_ values: [Value], for graph: __shared Graph) {
+  public init(_ values: [Value], forVerticesIn graph: __shared Graph) {
     assert(values.count == graph.vertexCount)
     self.init(values)
   }
 }
 
-extension TableVertexPropertyMap where Value: DefaultInitializable {
+extension TablePropertyMap where Value: DefaultInitializable {
   /// Initializes `self` with the default value for `count` verticies.
   public init(count: Int) {
     self.init(repeating: Value(), count: count)
   }
 }
 
-/// An external property map backed by a dictionary.
-public struct DictionaryEdgePropertyMap<Graph: GraphProtocol, Value>:
-  GraphEdgePropertyMap, MutableGraphEdgePropertyMap
-where Graph.EdgeId: Hashable {
-
-  /// The mapping of edges to values.
-  var values: [Graph.EdgeId: Value]
-
-  /// Initialize `self` providing `values` for each edge.
-  public init(_ values: [Graph.EdgeId: Value]) {
-    self.values = values
-  }
-
-  /// Retrieves the value for `edge` in `graph`.
-  public func get(_ graph: Graph, _ edge: Graph.EdgeId) -> Value {
-    values[edge]!
-  }
-
-  /// Sets `edge` in `graph` to `value`.
-  public mutating func set(edge: Graph.EdgeId, in graph: inout Graph, to value: Value) {
-    values[edge] = value
+extension TablePropertyMap where Graph: VertexListGraph, Graph.VertexId: IdIndexable, Value: DefaultInitializable {
+  public init(forVerticesIn graph: __shared Graph) {
+    self.init(repeating: Value(), count: graph.vertexCount)
   }
 }
 
-extension DictionaryEdgePropertyMap {
+/// An external property map backed by a dictionary.
+public struct DictionaryPropertyMap<Graph: GraphProtocol, Key, Value>: ExternalPropertyMap
+where Key: Hashable {
+
+  /// The mapping of edges to values.
+  var values: [Key: Value]
+
+  /// Initialize `self` providing `values` for each edge.
+  public init(_ values: [Key: Value]) {
+    self.values = values
+  }
+
+  public subscript(key: Key) -> Value {
+    get { values[key]! }
+    set { values[key] = newValue }
+  }
+}
+
+extension DictionaryPropertyMap where Graph.EdgeId: Hashable, Key == Graph.EdgeId {
   /// Initializes `self` using `values`; `graph` is unused, but helps type inference along nicely.
-  public init(_ values: [Graph.EdgeId: Value], for graph: __shared Graph) {
+  public init(_ values: [Graph.EdgeId: Value], forEdgesIn graph: __shared Graph) {
     self.init(values)
   }
 }

--- a/Sources/PenguinGraphs/VertexParallelProtocols.swift
+++ b/Sources/PenguinGraphs/VertexParallelProtocols.swift
@@ -369,11 +369,11 @@ public struct ParallelGraphAlgorithmContext<
   }
 
   /// Retrieve edge propreties.
-  public func getEdgeProperty<Map: GraphEdgePropertyMap>(
+  public func getEdgeProperty<Map: PropertyMap>(
     for edge: Graph.EdgeId,
     in map: Map
-  ) -> Map.Value where Map.Graph == Graph {
-    map.get(graph, edge)
+  ) -> Map.Value where Map.Graph == Graph, Map.Key == Graph.EdgeId {
+    map.get(edge, in: graph)
   }
 }
 
@@ -668,7 +668,7 @@ where
   public mutating func computeShortestPaths<
     Distance: GraphDistanceMeasure,
     Mailboxes: MailboxesProtocol,
-    DistanceMap: GraphEdgePropertyMap
+    DistanceMap: PropertyMap
   >(
     startingAt startVertex: VertexId,
     stoppingAt stopVertex: VertexId? = nil,
@@ -680,6 +680,7 @@ where
     Mailboxes.Mailbox.Graph == Self,
     Mailboxes.Mailbox.Message == DistanceSearchMessage<VertexId, Distance>,
     DistanceMap.Graph == Self,
+    DistanceMap.Key == EdgeId,
     DistanceMap.Value == Distance,
     Vertex.Distance == Distance
   {

--- a/Tests/PenguinGraphTests/DepthFirstSearchTests.swift
+++ b/Tests/PenguinGraphTests/DepthFirstSearchTests.swift
@@ -68,7 +68,7 @@ final class DepthFirstSearchTests: XCTestCase {
     let e3 = g.addEdge(from: v3, to: v4)
 
     var recorder = RecorderVisiter(expectedStart: v0)
-    var vertexVisitationState = TableVertexPropertyMap(repeating: VertexColor.white, for: g)
+    var vertexVisitationState = TablePropertyMap(repeating: VertexColor.white, forVerticesIn: g)
     g.depthFirstSearch(startingAt: v0, vertexVisitationState: &vertexVisitationState) { e, g in
       recorder.consume(e)
     }
@@ -91,7 +91,7 @@ final class DepthFirstSearchTests: XCTestCase {
     _ = g.addEdge(from: v1, to: v2)
 
     var recorder = RecorderVisiter(expectedStart: v0)
-    var vertexVisitationState = TableVertexPropertyMap(repeating: VertexColor.white, for: g)
+    var vertexVisitationState = TablePropertyMap(repeating: VertexColor.white, forVerticesIn: g)
     try g.depthFirstSearch(startingAt: v0, vertexVisitationState: &vertexVisitationState) { e, g in
       recorder.consume(e)
       if case let .discover(vertex) = e, vertex == v1 { throw GraphErrors.stopSearch }
@@ -143,7 +143,7 @@ final class DepthFirstSearchTests: XCTestCase {
     let e4 = g.addEdge(from: v4, to: v2)
 
     var recorder = RecorderVisiter(expectedStart: v0)
-    var vertexVisitationState = TableVertexPropertyMap(repeating: VertexColor.white, for: g)
+    var vertexVisitationState = TablePropertyMap(repeating: VertexColor.white, forVerticesIn: g)
     g.depthFirstSearch(startingAt: v0, vertexVisitationState: &vertexVisitationState) { e, g in
       recorder.consume(e)
     }
@@ -173,7 +173,7 @@ final class DepthFirstSearchTests: XCTestCase {
 
     var testRecorder = RecorderVisiter(expectedStart: v0)
     var predecessorVisitor = TablePredecessorRecorder(for: g)
-    var vertexVisitationState = TableVertexPropertyMap(repeating: VertexColor.white, for: g)
+    var vertexVisitationState = TablePropertyMap(repeating: VertexColor.white, forVerticesIn: g)
     g.depthFirstSearch(startingAt: v0, vertexVisitationState: &vertexVisitationState) { e, g in
       testRecorder.consume(e)
       predecessorVisitor.record(e, graph: g)

--- a/Tests/PenguinGraphTests/DijkstraSearchTests.swift
+++ b/Tests/PenguinGraphTests/DijkstraSearchTests.swift
@@ -57,9 +57,9 @@ final class DijkstraSearchTests: XCTestCase {
     let e2 = g.addEdge(from: v1, to: v3)  // 4
     let e3 = g.addEdge(from: v3, to: v4)  // 1
 
-    let edgeWeights = DictionaryEdgePropertyMap([e0: 2, e1: 3, e2: 4, e3: 1], for: g)
-    var vertexDistanceMap = TableVertexPropertyMap(repeating: Int.max, for: g)
-    var vertexVisitationState = TableVertexPropertyMap(repeating: VertexColor.white, for: g)
+    let edgeWeights = DictionaryPropertyMap([e0: 2, e1: 3, e2: 4, e3: 1], forEdgesIn: g)
+    var vertexDistanceMap = TablePropertyMap(repeating: Int.max, forVerticesIn: g)
+    var vertexVisitationState = TablePropertyMap(repeating: VertexColor.white, forVerticesIn: g)
     var recorder = Recorder()
 
     g.dijkstraSearch(
@@ -77,11 +77,11 @@ final class DijkstraSearchTests: XCTestCase {
     XCTAssertEqual([], recorder.notRelaxedEdges)
     XCTAssertEqual([v0, v1, v2, v3, v4], recorder.finishedVerticies)
 
-    XCTAssertEqual(0, vertexDistanceMap.get(g, v0))
-    XCTAssertEqual(2, vertexDistanceMap.get(g, v1))
-    XCTAssertEqual(5, vertexDistanceMap.get(g, v2))
-    XCTAssertEqual(6, vertexDistanceMap.get(g, v3))
-    XCTAssertEqual(7, vertexDistanceMap.get(g, v4))
+    XCTAssertEqual(0, vertexDistanceMap[v0])
+    XCTAssertEqual(2, vertexDistanceMap[v1])
+    XCTAssertEqual(5, vertexDistanceMap[v2])
+    XCTAssertEqual(6, vertexDistanceMap[v3])
+    XCTAssertEqual(7, vertexDistanceMap[v4])
   }
 
   func testMultiPath() throws {
@@ -103,11 +103,11 @@ final class DijkstraSearchTests: XCTestCase {
     let e4 = g.addEdge(from: v0, to: v3)  // 10
     let e5 = g.addEdge(from: v0, to: v4)  // 3
 
-    let edgeWeights = DictionaryEdgePropertyMap(
+    let edgeWeights = DictionaryPropertyMap(
       [e0: 2, e1: 3, e2: 4, e3: 1, e4: 10, e5: 3],
-      for: g)
-    var vertexDistanceMap = TableVertexPropertyMap(repeating: Int.max, for: g)
-    var vertexVisitationState = TableVertexPropertyMap(repeating: VertexColor.white, for: g)
+      forEdgesIn: g)
+    var vertexDistanceMap = TablePropertyMap(repeating: Int.max, forVerticesIn: g)
+    var vertexVisitationState = TablePropertyMap(repeating: VertexColor.white, forVerticesIn: g)
     var recorder = Recorder()
     var predecessors = TablePredecessorRecorder(for: g)
 
@@ -129,12 +129,12 @@ final class DijkstraSearchTests: XCTestCase {
     XCTAssertEqual([e3], recorder.notRelaxedEdges)
     XCTAssertEqual([v0, v1, v4, v2, v3], recorder.finishedVerticies)
 
-    XCTAssertEqual(0, vertexDistanceMap.get(g, v0))
-    XCTAssertEqual(2, vertexDistanceMap.get(g, v1))
-    XCTAssertEqual(5, vertexDistanceMap.get(g, v2))
-    XCTAssertEqual(6, vertexDistanceMap.get(g, v3))
-    XCTAssertEqual(3, vertexDistanceMap.get(g, v4))
-    XCTAssertEqual(Int.max, vertexDistanceMap.get(g, v5))
+    XCTAssertEqual(0, vertexDistanceMap[v0])
+    XCTAssertEqual(2, vertexDistanceMap[v1])
+    XCTAssertEqual(5, vertexDistanceMap[v2])
+    XCTAssertEqual(6, vertexDistanceMap[v3])
+    XCTAssertEqual(3, vertexDistanceMap[v4])
+    XCTAssertEqual(Int.max, vertexDistanceMap[v5])
 
     XCTAssertEqual([nil, v0, v1, v1, v0, nil], predecessors.predecessors)
   }

--- a/Tests/PenguinGraphTests/InternalPropertyMapTests.swift
+++ b/Tests/PenguinGraphTests/InternalPropertyMapTests.swift
@@ -44,11 +44,11 @@ final class InternalPropertyMapTests: XCTestCase {
     let v2 = g.addVertex(storing: ColoredNode(.black))
     let v3 = g.addVertex()
 
-    let map = InternalVertexPropertyMap(\ColoredNode.color, on: g)
+    let map = InternalVertexPropertyMap(for: g).transform(\.color)
 
-    XCTAssertEqual(.gray, map.get(g, v1))
-    XCTAssertEqual(.white, map.get(g, v3))
-    XCTAssertEqual(.black, map.get(g, v2))
+    XCTAssertEqual(.gray, map.get(v1, in: g))
+    XCTAssertEqual(.white, map.get(v3, in: g))
+    XCTAssertEqual(.black, map.get(v2, in: g))
   }
 
   func testSimpleEdgeProperty() {
@@ -61,11 +61,11 @@ final class InternalPropertyMapTests: XCTestCase {
     let e2 = g.addEdge(from: v2, to: v3, storing: WeightedEdge(2))
     let e3 = g.addEdge(from: v3, to: v1, storing: WeightedEdge(3))
 
-    let map = InternalEdgePropertyMap(\WeightedEdge.weight, on: g)
+    let map = InternalEdgePropertyMap(for: g).transform(\.weight)
 
-    XCTAssertEqual(3, map.get(g, e3))
-    XCTAssertEqual(2, map.get(g, e2))
-    XCTAssertEqual(1, map.get(g, e1))
+    XCTAssertEqual(3, map.get(e3, in: g))
+    XCTAssertEqual(2, map.get(e2, in: g))
+    XCTAssertEqual(1, map.get(e1, in: g))
   }
   static var allTests = [
     ("testSimpleVertexProperty", testSimpleVertexProperty),

--- a/Tests/PenguinGraphTests/ParallelExpanderTests.swift
+++ b/Tests/PenguinGraphTests/ParallelExpanderTests.swift
@@ -21,7 +21,7 @@ final class ParallelExpanderTests: XCTestCase {
 
   typealias LabelBundle = SIMDLabelBundle<SIMD3<Float>>
   typealias Graph = AdjacencyList<TestLabeledVertex, Empty, Int32>
-  typealias EdgeWeights = DictionaryEdgePropertyMap<Graph, Float>
+  typealias EdgeWeights = DictionaryPropertyMap<Graph, Graph.EdgeId, Float>
 
   func testSimple() {
     var g = Graph()

--- a/Tests/PenguinGraphTests/VertexParallelTests.swift
+++ b/Tests/PenguinGraphTests/VertexParallelTests.swift
@@ -115,7 +115,7 @@ final class VertexParallelTests: XCTestCase {
       sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
     let vIds = g.vertices
 
-    let edgeDistanceMap = InternalEdgePropertyMap(\TestDistanceEdge.distance, on: g)
+    let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
     XCTAssertEqual(
       6,
       g.computeShortestPaths(startingAt: vIds[0], distances: edgeDistanceMap, mailboxes: &mailboxes)
@@ -150,7 +150,7 @@ final class VertexParallelTests: XCTestCase {
       sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
     let vIds = g.vertices
 
-    let edgeDistanceMap = InternalEdgePropertyMap(\TestDistanceEdge.distance, on: g)
+    let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
     XCTAssertEqual(
       3,
       g.computeShortestPaths(
@@ -188,7 +188,7 @@ final class VertexParallelTests: XCTestCase {
       sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
     let vIds = g.vertices
 
-    let edgeDistanceMap = InternalEdgePropertyMap(\TestDistanceEdge.distance, on: g)
+    let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
     XCTAssertEqual(
       4,
       g.computeShortestPaths(
@@ -279,7 +279,7 @@ final class VertexParallelTests: XCTestCase {
         for: g,
         sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
 
-      let edgeDistanceMap = InternalEdgePropertyMap(\TestDistanceEdge.distance, on: g)
+      let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
       XCTAssertEqual(
         6,
         g.computeShortestPaths(
@@ -446,7 +446,7 @@ extension VertexParallelTests {
         sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
 
       let vIds = g.vertices
-      let edgeDistanceMap = InternalEdgePropertyMap(\TestDistanceEdge.distance, on: g)
+      let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
       XCTAssertEqual(
         6,
         g.computeShortestPaths(


### PR DESCRIPTION
Previously, things were separated into two parallel protocol families of
vertex property maps, and edge property maps. This made re-use of property
map implementations more difficult, as they had to be implemented for both
vertices as well as edges. Further, there was a non-trivial amount of
syntactic overhead for external property maps.

This change simplifies property maps by adding an extra associated type
to the base protocol. Once that has been added, it becomes trivial to
make an implementation that is generic over VertexId's and EdgeId's.
This has resulted in a significant simplification.

In addition, I've (for now) consolidated mutable and immutable property
map protocols into a single protocol. (This design decision might be
good to revisit in the future if this turns out to be problematic. For
the existing algorithms, this is not.)

There are a few bits of follow-up:

 1. Determine if it's possible to make helpful typealiases to reduce
    the amount of typing required to specify the where clause for a
    property map. Something like the following (which unfortunately
    doesn't compile):

    ```swift
    extension GraphProtocol {
      typealias VertexPropertyMap = PropertyMap where Graph == Self, Key == VertexId
    }
    ```

 2. Explore the space of property maps for use in vertex-parallel
    algorithms.
 3. Reevaluate the name `PropertyMap`.