### PR TITLE
First attempt at some pointer sugar.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,10 +74,13 @@ let package = Package(
             cSettings: [.define("SWIFT_OPT", .when(configuration: .release))]),
         .target(
             name: "PenguinStructures",
-            dependencies: []),
+            dependencies: ["PenguinPointers"]),
         .testTarget(
             name: "PenguinStructuresTests",
             dependencies: ["PenguinStructures"]),
+        .target(
+            name: "PenguinPointers",
+            dependencies: []),
         .target(
             name: "Benchmarks",
             dependencies: [

--- a/Sources/PenguinGraphs/VertexParallelProtocols.swift
+++ b/Sources/PenguinGraphs/VertexParallelProtocols.swift
@@ -14,6 +14,7 @@
 
 import PenguinParallel
 import PenguinStructures
+@_implementationOnly import PenguinPointers
 
 // MARK: - Mailboxes
 
@@ -178,10 +179,10 @@ public class PerThreadMailboxes<
       header.hasMessages = true
       withUnsafeMutablePointerToElements { buff in
         let ptr = buff.advanced(by: vertex.index)
-        if ptr.pointee == nil {
-          ptr.pointee = message
+        if ptr* == nil {
+          ptr.pointee = message  // :-(
         } else {
-          ptr.pointee!.merge(message)
+          ptr.pointee!.merge(message)  // :-(
         }
       }
     }
@@ -260,11 +261,11 @@ public class PerThreadMailboxes<
               var i = inboxP
               var o = outboxP
               for _ in 0..<inbox.count {
-                if i.pointee == nil {
+                if i* == nil {
                   i.moveInitialize(from: o, count: 1)
                 } else {
                   if let elem = o.move() {
-                    i.pointee!.merge(elem)
+                    i.pointee!.merge(elem)  // !!!
                   }
                 }
                 o.initialize(to: nil)
@@ -358,7 +359,7 @@ public struct ParallelGraphAlgorithmContext<
   }
 
   /// The merged message resulting from merging all the messages sent in the last parallel step.
-  public var inbox: Message? { mailbox.pointee.inbox }
+  public var inbox: Message? { mailbox*.inbox }
 
   /// Sends `message` to `vertex`, which will be received at the next step.
   public mutating func send(_ message: Message, to vertex: Graph.VertexId) {

--- a/Sources/PenguinPointers/PointerSugar.swift
+++ b/Sources/PenguinPointers/PointerSugar.swift
@@ -1,0 +1,32 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+postfix operator *
+infix operator *=: AssignmentPrecedence
+
+extension UnsafePointer {
+  public static postfix func * (_ ptr: UnsafePointer) -> Pointee {
+    ptr.pointee
+  }
+}
+
+extension UnsafeMutablePointer {
+  public static postfix func * (_ ptr: UnsafeMutablePointer) -> Pointee {
+    ptr.pointee
+  }
+
+  public static func *= (_ ptr: UnsafeMutablePointer, _ pointee: Pointee) {
+    ptr.pointee = pointee
+  }
+}

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+@_implementationOnly import PenguinPointers
+
 //******************************************************************************
 // This file exposes reference-counted buffer types similar to the storage for
 // `Array`, but designed to be (potentially) handled through type-erased APIs
@@ -92,7 +94,7 @@ extension ArrayStorageImplementation {
 
   /// The number of elements stored in `self`.
   public var count: Int {
-    _read { yield access.withUnsafeMutablePointerToHeader { $0.pointee.count } }
+    _read { yield access.withUnsafeMutablePointerToHeader { $0*.count } }
     _modify {
       defer { _fixLifetime(self) }
       yield &access.withUnsafeMutablePointerToHeader { $0 }.pointee.count
@@ -103,7 +105,7 @@ extension ArrayStorageImplementation {
   public var capacity: Int {
     _read {
       yield access.withUnsafeMutablePointerToHeader {
-        $0.pointee.capacity }
+        $0*.capacity }
     }
     _modify {
       defer { _fixLifetime(self) }
@@ -118,7 +120,7 @@ extension ArrayStorageImplementation {
     if r == capacity { return nil }
     access.withUnsafeMutablePointers { h, e in
       (e + r).initialize(to: x)
-      h[0].count = r + 1
+      h[0].count = r + 1  // TODO: THIS CAN'T BE SUPPORTED!
     }
     return r
   }
@@ -128,7 +130,7 @@ extension ArrayStorageImplementation {
     _ body: (inout UnsafeMutableBufferPointer<Element>) -> R
   ) -> R {
     access.withUnsafeMutablePointers { h, e in
-      var b = UnsafeMutableBufferPointer(start: e, count: h[0].count)
+      var b = UnsafeMutableBufferPointer(start: e, count: h*.count)
       return body(&b)
     }
   }
@@ -152,7 +154,7 @@ extension ArrayStorageImplementation {
   /// returning the index of the appended element, or `nil` if there was
   /// insufficient capacity remaining
   public func appendValue_(at p: UnsafeRawPointer) -> Int? {
-    append(p.assumingMemoryBound(to: Element.self)[0])
+    append(p.assumingMemoryBound(to: Element.self)*)
   }
 
   /// Invokes `body` with the memory occupied by initialized elements.
@@ -168,7 +170,7 @@ extension ArrayStorageImplementation {
   /// Deinitialize stored data. Models should call this from their `deinit`.
   public func deinitialize() {
     access.withUnsafeMutablePointers { h, e in
-      e.deinitialize(count: h[0].count)
+      e.deinitialize(count: h*.count)
       h.deinitialize(count: 1)
     }
   }


### PR DESCRIPTION
This, unfortunately, is somewhat unsatisfying, as it cannot obviate
all need for `.pointee`. In particular, it cannot satisfy the case
when the pointee needs to be modified in some fashion. (i.e. `inout`)