### PR TITLE
Remove stale comment.

### DIFF
--- a/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
+++ b/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
@@ -404,9 +404,6 @@ extension NonBlockingThreadPool where Environment: DefaultInitializable {
   public convenience init(name: String, threadCount: Int) {
     self.init(name: name, threadCount: threadCount, environment: Environment())
   }
-
-  // TODO: add a convenience initializer that automatically figures out the number of threads to
-  // use based on available processor threads.
 }
 
 fileprivate final class PerThreadState<Environment: ConcurrencyPlatform> {


### PR DESCRIPTION
The functionality referred to in the comment has been implemented in the
`PenguinParallelWithFoundation` package, which leverages the `Foundation`
dependency to query the number of available processors.