### PR TITLE
Factor out number operations from NonBlockingThreadPool.swift

### DIFF
--- a/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
+++ b/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
@@ -99,7 +99,7 @@ public class NonBlockingThreadPool<Environment: ConcurrencyPlatform>: ComputeThr
     let totalThreadCount = threadCount + externalFastPathThreadCount
     self.totalThreadCount = totalThreadCount
     self.externalFastPathThreadCount = externalFastPathThreadCount
-    self.coprimes = makeCoprimes(upTo: totalThreadCount)
+    self.coprimes = positiveCoprimes(totalThreadCount)
     self.queues = (0..<totalThreadCount).map { _ in Queue.make() }
     self.cancelledStorage = AtomicUInt64()
     self.blockedCountStorage = AtomicUInt64()

--- a/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
+++ b/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
@@ -511,49 +511,6 @@ fileprivate final class PerThreadState<Environment: ConcurrencyPlatform> {
   }
 }
 
-fileprivate func makeCoprimes(upTo n: Int) -> [Int] {
-  var coprimes = [Int]()
-  for i in 1...n {
-    var a = i
-    var b = n
-    // If GCD(a, b) == 1, then a and b are coprimes.
-    while b != 0 {
-      let tmp = a
-      a = b
-      b = tmp % b
-    }
-    if a == 1 { coprimes.append(i) }
-  }
-  return coprimes
-}
-
-/// Reduce `lhs` into `[0, size)`.
-///
-/// This is a faster variation than computing `x % size`. For additional context, please see:
-///     https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
-fileprivate func fastFit(_ lhs: Int, into size: Int) -> Int {
-  let l = UInt32(lhs)
-  let r = UInt32(size)
-  return Int(l.multipliedFullWidth(by: r).high)
-}
-
-/// Fast random number generator using [permuted congruential
-/// generators](https://en.wikipedia.org/wiki/Permuted_congruential_generator)
-fileprivate struct PCGRandomNumberGenerator {
-  var state: UInt64
-  static var stream: UInt64 { 0xda3e_39cb_94b9_5bdb }
-
-  mutating func next() -> UInt32 {
-    let current = state
-    // Update the internal state
-    state = current &* 6_364_136_223_846_793_005 &+ Self.stream
-    // Calculate output function (XSH-RS scheme), uses old state for max ILP.
-    let base = (current ^ (current >> 22))
-    let shift = Int(22 + (current >> 61))
-    return UInt32(truncatingIfNeeded: base >> shift)
-  }
-}
-
 fileprivate struct NonblockingSpinningState {
   var underlying: UInt64
 

--- a/Sources/PenguinParallel/NonblockingThreadPool/NumberOperations.swift
+++ b/Sources/PenguinParallel/NonblockingThreadPool/NumberOperations.swift
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Returns an array of all positive integers that are co-prime with `n`.
+/// Returns the positive integers that are coprime with `n`.
 ///
 /// Two numbers are co-prime if their GCD is 1.
-internal func makeCoprimes(upTo n: Int) -> [Int] {
+internal func positiveCoprimes(_ n: Int) -> [Int] {
   var coprimes = [Int]()
   for i in 1...n {
     var a = i
@@ -31,7 +31,7 @@ internal func makeCoprimes(upTo n: Int) -> [Int] {
   return coprimes
 }
 
-/// Reduce `lhs` into `[0, size)`.
+/// Returns a value deterministically selected from `0..<size`.
 ///
 /// This is a faster variation than computing `x % size`. For additional context, please see:
 ///     https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
@@ -41,9 +41,9 @@ internal func fastFit(_ lhs: Int, into size: Int) -> Int {
   return Int(l.multipliedFullWidth(by: r).high)
 }
 
-/// Fast random number generator using [permuted congruential
-/// generators](https://en.wikipedia.org/wiki/Permuted_congruential_generator)
-internal struct PCGRandomNumberGenerator {
+/// Fast pseudorandom number generator using [permuted congruential
+/// generators](https://www.pcg-random.org/).
+internal struct PCGRandomNumberGenerator: RandomNumberGenerator {
   var state: UInt64
   static var stream: UInt64 { 0xda3e_39cb_94b9_5bdb }
 

--- a/Sources/PenguinParallel/NonblockingThreadPool/NumberOperations.swift
+++ b/Sources/PenguinParallel/NonblockingThreadPool/NumberOperations.swift
@@ -1,0 +1,59 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Returns an array of all positive integers that are co-prime with `n`.
+///
+/// Two numbers are co-prime if their GCD is 1.
+internal func makeCoprimes(upTo n: Int) -> [Int] {
+  var coprimes = [Int]()
+  for i in 1...n {
+    var a = i
+    var b = n
+    // If GCD(a, b) == 1, then a and b are coprimes.
+    while b != 0 {
+      let tmp = a
+      a = b
+      b = tmp % b
+    }
+    if a == 1 { coprimes.append(i) }
+  }
+  return coprimes
+}
+
+/// Reduce `lhs` into `[0, size)`.
+///
+/// This is a faster variation than computing `x % size`. For additional context, please see:
+///     https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
+internal func fastFit(_ lhs: Int, into size: Int) -> Int {
+  let l = UInt32(lhs)
+  let r = UInt32(size)
+  return Int(l.multipliedFullWidth(by: r).high)
+}
+
+/// Fast random number generator using [permuted congruential
+/// generators](https://en.wikipedia.org/wiki/Permuted_congruential_generator)
+internal struct PCGRandomNumberGenerator {
+  var state: UInt64
+  static var stream: UInt64 { 0xda3e_39cb_94b9_5bdb }
+
+  mutating func next() -> UInt32 {
+    let current = state
+    // Update the internal state
+    state = current &* 6_364_136_223_846_793_005 &+ Self.stream
+    // Calculate output function (XSH-RS scheme), uses old state for max ILP.
+    let base = (current ^ (current >> 22))
+    let shift = Int(22 + (current >> 61))
+    return UInt32(truncatingIfNeeded: base >> shift)
+  }
+}


### PR DESCRIPTION
The file NonBlockingThreadPool.swift is a little long, and has grown a few
utility functions within it that aren't tightly coupled to the implementation.
This change factors them out into an adjacent file to simplify maintenance of
the NonBlockingThreadPool.