### PR TITLE
ComputeThreadPool cleanup (4/n): NonBlockingSpinningState to new file.

### DIFF
--- a/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingSpinningState.swift
+++ b/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingSpinningState.swift
@@ -1,0 +1,76 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO: once some version of atomics lands in Swift, refactor this to make it much nicer!
+
+/// A helper that packs the spinning state of the `NonBlockingThreadPool` into 64 bits.
+internal struct NonBlockingSpinningState {
+  var underlying: UInt64
+
+  init(_ underlying: UInt64) { self.underlying = underlying }
+
+  /// The number of spinning worker threads.
+  var spinningCount: UInt64 {
+    get {
+      underlying & Self.spinningCountMask
+    }
+    set {
+      assert(newValue < Self.spinningCountMask, "new value: \(newValue)")
+      underlying = (underlying & ~Self.spinningCountMask) | newValue
+    }
+  }
+
+  /// Number of non-notifying submissions into the pool.
+  var noNotifyCount: UInt64 {
+    (underlying & Self.noNotifyCountMask) >> Self.noNotifyCountShift
+  }
+
+  /// True iff a task has been submitted to the pool without notifying the thread pool's `condition`.
+  var hasNoNotifyTask: Bool {
+    (underlying & Self.noNotifyCountMask) != 0
+  }
+
+  /// Returns a new state with the the non-notifying count incremented by one.
+  func incrementingNoNotifyCount() -> Self {
+    Self(underlying + Self.noNotifyCountIncrement)
+  }
+
+  /// Decrements the non-notifying count by one.
+  mutating func decrementNoNotifyCount() {
+    underlying -= Self.noNotifyCountIncrement
+  }
+
+  /// Returns a new state with the spinning count incremented by one.
+  func incrementingSpinningCount() -> Self {
+    Self(underlying + 1)
+  }
+
+  /// Returns a new state with the spinning count decremented by one.
+  func decrementingSpinningCount() -> Self {
+    Self(underlying - 1)
+  }
+
+  static let spinningCountBits: UInt64 = 32
+  static let spinningCountMask: UInt64 = (1 << spinningCountBits) - 1
+  static let noNotifyCountBits: UInt64 = 32
+  static let noNotifyCountShift: UInt64 = 32
+  static let noNotifyCountMask: UInt64 = ((1 << noNotifyCountBits) - 1) << noNotifyCountShift
+  static let noNotifyCountIncrement: UInt64 = (1 << noNotifyCountShift)
+}
+
+extension NonBlockingSpinningState: CustomStringConvertible {
+  public var description: String {
+    "NonblockingSpinningState(spinningCount: \(spinningCount), noNotifyCount: \(noNotifyCount))"
+  }
+}

--- a/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
+++ b/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
@@ -157,9 +157,6 @@ public class NonBlockingThreadPool<Environment: ConcurrencyPlatform>: ComputeThr
     }
   }
 
-  // TODO: Add API to allow expressing parallelFor without requiring closure allocations & test
-  // to see if that improves performance or not.
-
   public func join(_ a: Task, _ b: Task) {
     // add `b` to the work queue (and execute it immediately if queue is full).
     // if added to the queue, maybe wakeup worker if required.
@@ -335,7 +332,7 @@ extension NonBlockingThreadPool {
   /// If there are threads spinning in the steal loop, there is no need to unpark a waiting thread,
   /// as the task will get picked up by one of the spinners.
   private func wakeupWorkerIfRequired() {
-    var state = NonblockingSpinningState(spinningState.valueRelaxed)
+    var state = NonBlockingSpinningState(spinningState.valueRelaxed)
     while true {
       // if the number of tasks submitted without notifying parked threads is equal to the number of
       // spinning threads, we must wake up one of the parked threads
@@ -354,7 +351,7 @@ extension NonBlockingThreadPool {
   fileprivate func shouldStartSpinning() -> Bool {
     if activeThreadCount > Constants.minActiveThreadsToStartSpinning { return false }  // ???
 
-    var state = NonblockingSpinningState(spinningState.valueRelaxed)
+    var state = NonBlockingSpinningState(spinningState.valueRelaxed)
     while true {
       if (state.spinningCount - state.noNotifyCount) >= Constants.maxSpinningThreads {
         return false
@@ -370,7 +367,7 @@ extension NonBlockingThreadPool {
   ///
   /// - Returns: `true` if there is a task to steal; false otherwise.
   fileprivate func stopSpinning() -> Bool {
-    var state = NonblockingSpinningState(spinningState.valueRelaxed)
+    var state = NonBlockingSpinningState(spinningState.valueRelaxed)
     while true {
       var newState = state.decrementingSpinningCount()
 
@@ -404,9 +401,6 @@ extension NonBlockingThreadPool where Environment: DefaultInitializable {
   public convenience init(name: String, threadCount: Int) {
     self.init(name: name, threadCount: threadCount, environment: Environment())
   }
-
-  // TODO: add a convenience initializer that automatically figures out the number of threads to
-  // use based on available processor threads.
 }
 
 fileprivate final class PerThreadState<Environment: ConcurrencyPlatform> {
@@ -551,59 +545,6 @@ fileprivate struct PCGRandomNumberGenerator {
     let base = (current ^ (current >> 22))
     let shift = Int(22 + (current >> 61))
     return UInt32(truncatingIfNeeded: base >> shift)
-  }
-}
-
-fileprivate struct NonblockingSpinningState {
-  var underlying: UInt64
-
-  init(_ underlying: UInt64) { self.underlying = underlying }
-
-  var spinningCount: UInt64 {
-    get {
-      underlying & Self.spinningCountMask
-    }
-    set {
-      assert(newValue < Self.spinningCountMask, "new value: \(newValue)")
-      underlying = (underlying & ~Self.spinningCountMask) | newValue
-    }
-  }
-
-  var noNotifyCount: UInt64 {
-    (underlying & Self.noNotifyCountMask) >> Self.noNotifyCountShift
-  }
-
-  var hasNoNotifyTask: Bool {
-    (underlying & Self.noNotifyCountMask) != 0
-  }
-
-  func incrementingNoNotifyCount() -> Self {
-    Self(underlying + Self.noNotifyCountIncrement)
-  }
-
-  mutating func decrementNoNotifyCount() {
-    underlying -= Self.noNotifyCountIncrement
-  }
-
-  func incrementingSpinningCount() -> Self {
-    Self(underlying + 1)
-  }
-
-  func decrementingSpinningCount() -> Self {
-    Self(underlying - 1)
-  }
-
-  static let spinningCountBits: UInt64 = 32
-  static let spinningCountMask: UInt64 = (1 << spinningCountBits) - 1
-  static let noNotifyCountBits: UInt64 = 32
-  static let noNotifyCountShift: UInt64 = 32
-  static let noNotifyCountMask: UInt64 = ((1 << noNotifyCountBits) - 1) << noNotifyCountShift
-  static let noNotifyCountIncrement: UInt64 = (1 << noNotifyCountShift)
-}
-
-extension NonblockingSpinningState: CustomStringConvertible {
-  public var description: String {
-    "NonblockingSpinningState(spinningCount: \(spinningCount), noNotifyCount: \(noNotifyCount))"
   }
 }
 


### PR DESCRIPTION
This change moves `NonBlockingSpinningState` to its own file to reduce the size of the
`NonBlockingThreadPool.swift` file.