### PR TITLE
Rewrite the heap and related priority queue structures.

### DIFF
--- a/Sources/PenguinGraphs/DijkstraSearch.swift
+++ b/Sources/PenguinGraphs/DijkstraSearch.swift
@@ -65,22 +65,38 @@ public enum DijkstraSearchEvent<SearchSpace: GraphProtocol> {
   case finish(Vertex)
 }
 
-// TODO: consider making this more generic / reusible!
-private struct HeapQueue<Element: Hashable & IdIndexable, Priority: Comparable & GraphDistanceMeasure>: Queue {
-  typealias Underlying = ConfigurableHeap<
-    Element,
-    Priority,
-    Int32,  // TODO: make configurable!
-    _IdIndexibleDictionaryHeapIndexer<Element, _ConfigurableHeapCursor<Int32>>
+/// Adapters a PriortyQueue to a BFS-compatible Queue.
+private struct DijkstraQueue<
+  Distance: GraphDistanceMeasure,
+  VertexId,
+  Heap: RandomAccessCollection & RangeReplaceableCollection & MutableCollection,
+  ElementLocations: PriorityQueueIndexer
+>: Queue
+where
+  Heap.Element == PriorityQueueElement<Distance, VertexId>,
+  ElementLocations.Key == VertexId,
+  ElementLocations.Value == Heap.Index
+{
+  /// The type of the backing priority queue.
+  typealias Underlying = PriorityQueue<
+    Distance,
+    VertexId,
+    Heap,
+    ElementLocations
   >
-  var underlying = Underlying()
 
-  mutating func push(_ element: Element) {
-    underlying.add(element, with: Priority.effectiveInfinity)
+  /// The backing priority queue.
+  var underlying: Underlying
+
+  /// Adds `vertex` to the underlying priority queue with `effectiveInfinity` priority.
+  mutating func push(_ vertex: VertexId) {
+    // TODO: take `effectiveInfinity` as a value.
+    underlying.push(vertex, at: Distance.effectiveInfinity)
   }
 
-  mutating func pop() -> Element? {
-    underlying.popFront()
+  /// Removes and returns the next vertex to examine.
+  mutating func pop() -> VertexId? {
+    underlying.pop()?.payload
   }
 }
 
@@ -89,20 +105,22 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
   /// A hook to observe events that occur during Dijkstra's search.
   public typealias DijkstraSearchCallback = (DijkstraSearchEvent<Self>, inout Self) throws -> Void
 
-  // TODO: modify to take a Priority Queue. Also update doc comment about initialization of data structures!
-
   /// Executes Dijkstra's graph search algorithm in `self` using the supplied property maps; 
   /// `callback` is called at key events during the search.
   public mutating func dijkstraSearch<
     Distance: GraphDistanceMeasure,
     EdgeLengths: PropertyMap,
     DistancesToVertex: PropertyMap,
-    VertexVisitationState: PropertyMap
+    VertexVisitationState: PropertyMap,
+    WorkList: RandomAccessCollection & RangeReplaceableCollection & MutableCollection & DefaultInitializable,
+    WorkListIndex: PriorityQueueIndexer & IndexProtocol
   >(
     startingAt startVertex: VertexId,
     vertexVisitationState: inout VertexVisitationState,
     distancesToVertex: inout DistancesToVertex,
     edgeLengths: EdgeLengths,
+    workListType: WorkList.Type,
+    workListIndex: WorkListIndex,
     callback: DijkstraSearchCallback
   ) rethrows
   where
@@ -114,10 +132,15 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
     DistancesToVertex.Value == Distance,
     VertexVisitationState.Graph == Self,
     VertexVisitationState.Key == VertexId,
-    VertexVisitationState.Value == VertexColor
+    VertexVisitationState.Value == VertexColor,
+    WorkList.Element == PriorityQueueElement<Distance, VertexId>,
+    WorkListIndex.Key == VertexId,
+    WorkListIndex.Value == WorkList.Index
   {
     distancesToVertex.set(startVertex, in: &self, to: Distance.zero)
-    var workList = HeapQueue<VertexId, Distance>()
+    var workList = DijkstraQueue<Distance, VertexId, WorkList, WorkListIndex>(underlying:
+      PriorityQueue<Distance, VertexId, WorkList, WorkListIndex>(
+        heap: WorkList(), locations: workListIndex))
     try breadthFirstSearch(
       startingAt: [startVertex],
       workList: &workList,
@@ -186,6 +209,8 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
       vertexVisitationState: &vertexVisitationState,
       distancesToVertex: &distancesToVertex,
       edgeLengths: edgeLengths,
+      workListType: [PriorityQueueElement<Distance, VertexId>].self,
+      workListIndex: ArrayPriorityQueueIndexer(count: vertexCount),
       callback: callback)
 
     return distancesToVertex

--- a/Sources/PenguinGraphs/DijkstraSearch.swift
+++ b/Sources/PenguinGraphs/DijkstraSearch.swift
@@ -65,7 +65,7 @@ public enum DijkstraSearchEvent<SearchSpace: GraphProtocol> {
   case finish(Vertex)
 }
 
-/// Adapters a PriortyQueue to a BFS-compatible Queue.
+/// Adapts a `PriortyQueue` to a BFS-compatible `Queue`.
 private struct DijkstraQueue<
   Distance: GraphDistanceMeasure,
   VertexId,
@@ -112,14 +112,14 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
     EdgeLengths: PropertyMap,
     DistancesToVertex: PropertyMap,
     VertexVisitationState: PropertyMap,
-    WorkList: RandomAccessCollection & RangeReplaceableCollection & MutableCollection & DefaultInitializable,
+    WorkList: RandomAccessCollection & RangeReplaceableCollection & MutableCollection,
     WorkListIndex: PriorityQueueIndexer & IndexProtocol
   >(
     startingAt startVertex: VertexId,
     vertexVisitationState: inout VertexVisitationState,
     distancesToVertex: inout DistancesToVertex,
     edgeLengths: EdgeLengths,
-    workListType: WorkList.Type,
+    workList: WorkList,
     workListIndex: WorkListIndex,
     callback: DijkstraSearchCallback
   ) rethrows
@@ -140,7 +140,7 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
     distancesToVertex.set(startVertex, in: &self, to: Distance.zero)
     var workList = DijkstraQueue<Distance, VertexId, WorkList, WorkListIndex>(underlying:
       PriorityQueue<Distance, VertexId, WorkList, WorkListIndex>(
-        heap: WorkList(), locations: workListIndex))
+        heap: workList, locations: workListIndex))
     try breadthFirstSearch(
       startingAt: [startVertex],
       workList: &workList,
@@ -209,7 +209,7 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
       vertexVisitationState: &vertexVisitationState,
       distancesToVertex: &distancesToVertex,
       edgeLengths: edgeLengths,
-      workListType: [PriorityQueueElement<Distance, VertexId>].self,
+      workList: [PriorityQueueElement<Distance, VertexId>](),
       workListIndex: ArrayPriorityQueueIndexer(count: vertexCount),
       callback: callback)
 

--- a/Sources/PenguinStructures/DefaultInitializable.swift
+++ b/Sources/PenguinStructures/DefaultInitializable.swift
@@ -19,3 +19,4 @@ public protocol DefaultInitializable {
 }
 
 extension Array: DefaultInitializable {}
+extension Dictionary: DefaultInitializable {}

--- a/Sources/PenguinStructures/DefaultInitializable.swift
+++ b/Sources/PenguinStructures/DefaultInitializable.swift
@@ -17,3 +17,5 @@ public protocol DefaultInitializable {
   /// Initialize `self` with default values. `self` must be in a valid (but unspecified) state.
   init()
 }
+
+extension Array: DefaultInitializable {}

--- a/Sources/PenguinStructures/Heap.swift
+++ b/Sources/PenguinStructures/Heap.swift
@@ -22,21 +22,23 @@ extension RandomAccessCollection where Self: MutableCollection, Element: Compara
   /// `HeapIndexRecorder` that is called once for every element that is moved during the heap
   /// modification. This flexibility allows some heap implementations to keep track of the
   /// locations of elements within the heap, allowing for efficient reprioritization.
-  public typealias HeapIndexRecorder = (Element, Index?) -> Void
+  public typealias HeapChangeListener = (_ justMoved: Element, _ newIndex: Index?) -> Void
 
   /// Records no information.
-  public static var noOpHeapIndexRecorder: HeapIndexRecorder { { _, _ in } }
+  public static var noOpHeapChangeListener: HeapChangeListener { { _, _ in } }
 
-  /// Arranges `self` according to a binary min-heap.
-  public mutating func arrangeAsMinHeap(indexRecorder: HeapIndexRecorder = noOpHeapIndexRecorder) {
+  /// Reorders `self` as a [binary heap](https://en.wikipedia.org/wiki/Heap_(data_structure))
+  /// with a minimal element at the top.
+  public mutating func reorderAsMinHeap(indexRecorder: HeapChangeListener = noOpHeapChangeListener) {
     for i in (0...((count + 1) / 2)).reversed() {
       minHeapSinkDown(startingAt: index(startIndex, offsetBy: i), indexRecorder: indexRecorder)
     }
   }
 
-  /// Restores binary heap invariants by repeatedly swapping the element at `index` with its
-  /// children.
-  public mutating func minHeapSinkDown(startingAt index: Index, indexRecorder: HeapIndexRecorder) {
+  /// Establishes a binary heap relationship between `index` and its children.
+  ///
+  /// - Precondition: binary heap invariants are satisfied for all children of the element at `index`.
+  public mutating func minHeapSinkDown(startingAt index: Index, indexRecorder: HeapChangeListener) {
     var i = index
     while true {
       var minIndex = i

--- a/Tests/PenguinGraphTests/DijkstraSearchTests.swift
+++ b/Tests/PenguinGraphTests/DijkstraSearchTests.swift
@@ -112,7 +112,7 @@ final class DijkstraSearchTests: XCTestCase {
       vertexVisitationState: &vertexVisitationState,
       distancesToVertex: &vertexDistanceMap,
       edgeLengths: edgeWeights,
-      workListType: [PriorityQueueElement<Int, Int>].self,
+      workList: [PriorityQueueElement<Int, Int>](),
       workListIndex: ArrayPriorityQueueIndexer(count: g.vertexCount)
     ) { e, g in
       recorder.consume(e)

--- a/Tests/PenguinGraphTests/DijkstraSearchTests.swift
+++ b/Tests/PenguinGraphTests/DijkstraSearchTests.swift
@@ -58,14 +58,10 @@ final class DijkstraSearchTests: XCTestCase {
     let e3 = g.addEdge(from: v3, to: v4)  // 1
 
     let edgeWeights = DictionaryPropertyMap([e0: 2, e1: 3, e2: 4, e3: 1], forEdgesIn: g)
-    var vertexDistanceMap = TablePropertyMap(repeating: Int.max, forVerticesIn: g)
-    var vertexVisitationState = TablePropertyMap(repeating: VertexColor.white, forVerticesIn: g)
     var recorder = Recorder()
 
-    g.dijkstraSearch(
+    let vertexDistances = g.dijkstraSearch(
       startingAt: v0,
-      vertexVisitationState: &vertexVisitationState,
-      distancesToVertex: &vertexDistanceMap,
       edgeLengths: edgeWeights
     ) { e, g in recorder.consume(e) }
 
@@ -77,11 +73,11 @@ final class DijkstraSearchTests: XCTestCase {
     XCTAssertEqual([], recorder.notRelaxedEdges)
     XCTAssertEqual([v0, v1, v2, v3, v4], recorder.finishedVerticies)
 
-    XCTAssertEqual(0, vertexDistanceMap[v0])
-    XCTAssertEqual(2, vertexDistanceMap[v1])
-    XCTAssertEqual(5, vertexDistanceMap[v2])
-    XCTAssertEqual(6, vertexDistanceMap[v3])
-    XCTAssertEqual(7, vertexDistanceMap[v4])
+    XCTAssertEqual(0, vertexDistances[v0])
+    XCTAssertEqual(2, vertexDistances[v1])
+    XCTAssertEqual(5, vertexDistances[v2])
+    XCTAssertEqual(6, vertexDistances[v3])
+    XCTAssertEqual(7, vertexDistances[v4])
   }
 
   func testMultiPath() throws {
@@ -115,7 +111,9 @@ final class DijkstraSearchTests: XCTestCase {
       startingAt: v0,
       vertexVisitationState: &vertexVisitationState,
       distancesToVertex: &vertexDistanceMap,
-      edgeLengths: edgeWeights
+      edgeLengths: edgeWeights,
+      workListType: [PriorityQueueElement<Int, Int>].self,
+      workListIndex: ArrayPriorityQueueIndexer(count: g.vertexCount)
     ) { e, g in
       recorder.consume(e)
       predecessors.record(e, graph: g)

--- a/Tests/PenguinStructuresTests/HeapTests.swift
+++ b/Tests/PenguinStructuresTests/HeapTests.swift
@@ -16,51 +16,83 @@ import PenguinStructures
 import XCTest
 
 final class HeapTests: XCTestCase {
+  func testHeapOperations() {
+    var a = [0, 1, 2, 3, 4, 5, 6]
+    XCTAssert(a.isMinHeap)
+
+    XCTAssertEqual(0, a.popMinHeap())
+    XCTAssertEqual([1, 3, 2, 6, 4, 5], a)
+    XCTAssert(a.isMinHeap)
+
+    XCTAssertEqual(1, a.popMinHeap())
+    XCTAssertEqual([2, 3, 5, 6, 4], a)
+    XCTAssert(a.isMinHeap)
+
+    for i in 2..<7 {
+      XCTAssertEqual(i, a.popMinHeap())
+      XCTAssert(a.isMinHeap)
+    }
+    XCTAssertNil(a.popMinHeap())
+    XCTAssert(a.isMinHeap)
+    a.insertMinHeap(42)
+    XCTAssert(a.isMinHeap)
+    XCTAssertEqual([42], a)
+
+    a = [3, 2, 1, 5, 7, 8, 0, 17, 8]
+    a.arrangeAsMinHeap()
+    XCTAssert(a.isMinHeap)
+
+    a.insertMinHeap(0)
+    XCTAssert(a.isMinHeap)
+    XCTAssertEqual([0, 0, 1, 5, 2, 8, 3, 17, 8, 7], a)
+  }
+
   func testSimple() {
-    var h = SimpleHeap<Int>()
+    var h = SimplePriorityQueue<Int>()
 
     let insertSequence = Array(0..<100).shuffled()
     for i in insertSequence {
-      h.add(i, with: i)
+      h.push(i, at: i)
     }
     for i in 0..<100 {
-      XCTAssertEqual(i, h.popFront())
+      XCTAssertEqual(i, h.pop()?.payload)
     }
-    XCTAssertEqual(nil, h.popFront())
+    XCTAssertNil(h.pop())
   }
 
   func testUpdatableUniqueHeapSimple() {
-    var h = makeReprioritizableHeap()
-    XCTAssertEqual("x", h.popFront())
-    XCTAssertEqual("y", h.popFront())
-    XCTAssertEqual("z", h.popFront())
-    XCTAssertEqual(nil, h.popFront())
+    // var h = makeReprioritizableHeap()
+    // XCTAssertEqual("x", h.popFront())
+    // XCTAssertEqual("y", h.popFront())
+    // XCTAssertEqual("z", h.popFront())
+    // XCTAssertEqual(nil, h.popFront())
 
-    h = makeReprioritizableHeap()
-    h.update("x", withNewPriority: 20)
-    XCTAssertEqual("y", h.popFront())
-    XCTAssertEqual("z", h.popFront())
-    XCTAssertEqual("x", h.popFront())
-    XCTAssertEqual(nil, h.popFront())
+    // h = makeReprioritizableHeap()
+    // h.update("x", withNewPriority: 20)
+    // XCTAssertEqual("y", h.popFront())
+    // XCTAssertEqual("z", h.popFront())
+    // XCTAssertEqual("x", h.popFront())
+    // XCTAssertEqual(nil, h.popFront())
 
-    h = makeReprioritizableHeap()
-    h.update("z", withNewPriority: 5)
-    XCTAssertEqual("z", h.popFront())
-    XCTAssertEqual("x", h.popFront())
-    XCTAssertEqual("y", h.popFront())
-    XCTAssertEqual(nil, h.popFront())
+    // h = makeReprioritizableHeap()
+    // h.update("z", withNewPriority: 5)
+    // XCTAssertEqual("z", h.popFront())
+    // XCTAssertEqual("x", h.popFront())
+    // XCTAssertEqual("y", h.popFront())
+    // XCTAssertEqual(nil, h.popFront())
   }
 
-  func makeReprioritizableHeap() -> ReprioritizableHeap<String> {
-    var h = ReprioritizableHeap<String>()
-    h.add("x", with: 10)
-    h.add("y", with: 11)
-    h.add("z", with: 12)
+  // func makeReprioritizableHeap() -> ReprioritizableHeap<String> {
+  //   var h = ReprioritizableHeap<String>()
+  //   h.add("x", with: 10)
+  //   h.add("y", with: 11)
+  //   h.add("z", with: 12)
 
-    return h
-  }
+  //   return h
+  // }
 
   static var allTests = [
+    ("testHeapOperations", testHeapOperations),
     ("testSimple", testSimple),
     ("testUpdatableUniqueHeapSimple", testUpdatableUniqueHeapSimple),
   ]

--- a/Tests/PenguinStructuresTests/HeapTests.swift
+++ b/Tests/PenguinStructuresTests/HeapTests.swift
@@ -39,7 +39,7 @@ final class HeapTests: XCTestCase {
     XCTAssertEqual([42], a)
 
     a = [3, 2, 1, 5, 7, 8, 0, 17, 8]
-    a.arrangeAsMinHeap()
+    a.reorderAsMinHeap()
     XCTAssert(a.isMinHeap)
 
     a.insertMinHeap(0)
@@ -75,7 +75,7 @@ final class HeapTests: XCTestCase {
       }
     }
 
-    heap.arrangeAsMinHeap { indexes[$0] = $1 }
+    heap.reorderAsMinHeap { indexes[$0] = $1 }
     XCTAssert(indexes.table.allSatisfy { $0 != nil }, "\(indexes)")
     assertIndexConsistent()
 


### PR DESCRIPTION
This change moves the heap related algorithms to operate generically on
`Collection` (and its various refinements). In doing so, the algorithms
become far more general and reusable.

Further, we re-build the PriorityQueue type, solving the indexing TODO's
that plagued the previous implementation.

Finally, we update all the rest of the code to use the new API.