### PR TITLE
Remove the `GraphDistanceMeasure` protocol, as it is no longer needed.

### DIFF
--- a/Sources/PenguinGraphs/DijkstraSearch.swift
+++ b/Sources/PenguinGraphs/DijkstraSearch.swift
@@ -14,26 +14,6 @@
 
 import PenguinStructures
 
-/// Represents a distance measure on a graph.
-public protocol GraphDistanceMeasure: AdditiveArithmetic, Comparable {
-  /// A value that is effectively always higher than any reasonable possible distance within the
-  /// graph.
-  static var effectiveInfinity: Self { get }
-}
-
-extension GraphDistanceMeasure where Self: FixedWidthInteger {
-  public static var effectiveInfinity: Self { Self.max }
-}
-
-extension GraphDistanceMeasure where Self: FloatingPoint {
-  public static var effectiveInfinity: Self { Self.infinity }
-}
-
-extension Int: GraphDistanceMeasure {}
-extension Int32: GraphDistanceMeasure {}
-extension Float: GraphDistanceMeasure {}
-extension Double: GraphDistanceMeasure {}
-
 /// The events that occur during Dijkstra's search within a graph.
 ///
 /// - SeeAlso: `IncidenceGraph.VertexListGraph`.
@@ -67,7 +47,7 @@ public enum DijkstraSearchEvent<SearchSpace: GraphProtocol> {
 
 /// Adapts a `PriortyQueue` to a BFS-compatible `Queue`.
 private struct DijkstraQueue<
-  Distance: GraphDistanceMeasure,
+  Distance: Comparable & AdditiveArithmetic,
   VertexId,
   Heap: RandomAccessCollection & RangeReplaceableCollection & MutableCollection,
   ElementLocations: PriorityQueueIndexer
@@ -87,11 +67,11 @@ where
 
   /// The backing priority queue.
   var underlying: Underlying
+  var effectivelyInfinite: Distance
 
-  /// Adds `vertex` to the underlying priority queue with `effectiveInfinity` priority.
+  /// Adds `vertex` to the underlying priority queue with `effectivelyInfinite` priority.
   mutating func push(_ vertex: VertexId) {
-    // TODO: take `effectiveInfinity` as a value.
-    underlying.push(vertex, at: Distance.effectiveInfinity)
+    underlying.push(vertex, at: effectivelyInfinite)
   }
 
   /// Removes and returns the next vertex to examine.
@@ -108,7 +88,7 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
   /// Executes Dijkstra's graph search algorithm in `self` using the supplied property maps; 
   /// `callback` is called at key events during the search.
   public mutating func dijkstraSearch<
-    Distance: GraphDistanceMeasure,
+    Distance: Comparable & AdditiveArithmetic,
     EdgeLengths: PropertyMap,
     DistancesToVertex: PropertyMap,
     VertexVisitationState: PropertyMap,
@@ -121,6 +101,7 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
     edgeLengths: EdgeLengths,
     workList: WorkList,
     workListIndex: WorkListIndex,
+    effectivelyInfinite: Distance,
     callback: DijkstraSearchCallback
   ) rethrows
   where
@@ -138,9 +119,10 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
     WorkListIndex.Value == WorkList.Index
   {
     distancesToVertex.set(startVertex, in: &self, to: Distance.zero)
-    var workList = DijkstraQueue<Distance, VertexId, WorkList, WorkListIndex>(underlying:
-      PriorityQueue<Distance, VertexId, WorkList, WorkListIndex>(
-        heap: workList, locations: workListIndex))
+    var workList = DijkstraQueue<Distance, VertexId, WorkList, WorkListIndex>(
+      underlying: PriorityQueue<Distance, VertexId, WorkList, WorkListIndex>(
+        heap: workList, locations: workListIndex),
+      effectivelyInfinite: effectivelyInfinite)
     try breadthFirstSearch(
       startingAt: [startVertex],
       workList: &workList,
@@ -187,7 +169,37 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
   /// Executes Dijkstra's search algorithm over `self` from `startVertex` using edge weights from
   /// `edgeLengths`; `callback` is called at key events of the search.
   public mutating func dijkstraSearch<
-    Distance: GraphDistanceMeasure,
+    Distance: Comparable & AdditiveArithmetic,
+    EdgeLengths: PropertyMap
+  >(
+    startingAt startVertex: VertexId,
+    edgeLengths: EdgeLengths,
+    effectivelyInfinite: Distance,
+    callback: DijkstraSearchCallback
+  ) rethrows -> TablePropertyMap<Self, VertexId, Distance>
+  where
+    EdgeLengths.Graph == Self,
+    EdgeLengths.Key == EdgeId,
+    EdgeLengths.Value == Distance
+  {
+    var vertexVisitationState = TablePropertyMap(repeating: VertexColor.white, forVerticesIn: self)
+    var distancesToVertex = TablePropertyMap(repeating: effectivelyInfinite, forVerticesIn: self)
+
+    try dijkstraSearch(
+      startingAt: startVertex,
+      vertexVisitationState: &vertexVisitationState,
+      distancesToVertex: &distancesToVertex,
+      edgeLengths: edgeLengths,
+      workList: [PriorityQueueElement<Distance, VertexId>](),
+      workListIndex: ArrayPriorityQueueIndexer(count: vertexCount),
+      effectivelyInfinite: effectivelyInfinite,
+      callback: callback)
+
+    return distancesToVertex
+  }
+
+  public mutating func dijkstraSearch<
+    Distance: FixedWidthInteger,
     EdgeLengths: PropertyMap
   >(
     startingAt startVertex: VertexId,
@@ -199,20 +211,22 @@ extension IncidenceGraph where Self: VertexListGraph, VertexId: IdIndexable & Ha
     EdgeLengths.Key == EdgeId,
     EdgeLengths.Value == Distance
   {
-    var vertexVisitationState = TablePropertyMap(repeating: VertexColor.white, forVerticesIn: self)
-    var distancesToVertex = TablePropertyMap(
-      repeating: Distance.effectiveInfinity,
-      forVerticesIn: self)
+    try dijkstraSearch(startingAt: startVertex, edgeLengths: edgeLengths, effectivelyInfinite: Distance.max, callback: callback)
+  }
 
-    try dijkstraSearch(
-      startingAt: startVertex,
-      vertexVisitationState: &vertexVisitationState,
-      distancesToVertex: &distancesToVertex,
-      edgeLengths: edgeLengths,
-      workList: [PriorityQueueElement<Distance, VertexId>](),
-      workListIndex: ArrayPriorityQueueIndexer(count: vertexCount),
-      callback: callback)
-
-    return distancesToVertex
+  public mutating func dijkstraSearch<
+    Distance: FloatingPoint,
+    EdgeLengths: PropertyMap
+  >(
+    startingAt startVertex: VertexId,
+    edgeLengths: EdgeLengths,
+    callback: DijkstraSearchCallback
+  ) rethrows -> TablePropertyMap<Self, VertexId, Distance>
+  where
+    EdgeLengths.Graph == Self,
+    EdgeLengths.Key == EdgeId,
+    EdgeLengths.Value == Distance
+  {
+    try dijkstraSearch(startingAt: startVertex, edgeLengths: edgeLengths, effectivelyInfinite: Distance.infinity, callback: callback)
   }
 }

--- a/Sources/PenguinGraphs/VertexParallelProtocols.swift
+++ b/Sources/PenguinGraphs/VertexParallelProtocols.swift
@@ -512,7 +512,7 @@ public protocol DistanceVertex {
   /// A "pointer" to the parent in the search tree.
   associatedtype VertexId
   /// A measure of the distance within the graph.
-  associatedtype Distance: GraphDistanceMeasure
+  associatedtype Distance: Comparable & AdditiveArithmetic
 
   /// The distance from the start vertex (verticies).
   var distance: Distance { get set }
@@ -523,18 +523,9 @@ public protocol DistanceVertex {
   var predecessor: VertexId? { get set }
 }
 
-/// An edge with associated distance.
-public protocol DistanceEdge {
-  /// The distance measure for the edge.
-  associatedtype Distance: GraphDistanceMeasure
-
-  /// The distance cost for traversing this edge.
-  var distance: Distance { get }
-}
-
 // Note: this must be made public due to Swift's lack of higher-kinded types.
 /// Messages used during parallel BFS and parallel shortest paths.
-public struct DistanceSearchMessage<VertexId, Distance: GraphDistanceMeasure>: MergeableMessage {
+public struct DistanceSearchMessage<VertexId, Distance: Comparable & AdditiveArithmetic>: MergeableMessage {
   var predecessor: VertexId
   var distance: Distance
 
@@ -557,12 +548,12 @@ where
   /// Executes breadth first search in parallel.
   ///
   /// Note: distances are not kept track of during BFS; at the conclusion of this algorithm,
-  /// the `vertex.distance` will be `.zero` if it's reachable, and `.effectiveInfinity` otherwise.
+  /// the `vertex.distance` will be `.zero` if it's reachable, and `effectivelyInfinite` otherwise.
   ///
-  /// - Parameter startVerticies: The verticies to begin search at.
+  /// - Parameter startVertex: The verticies to begin search at.
   /// - Returns: the number of steps taken to compute the closure (aka longest path length).
   public mutating func computeBFS<
-    Distance: GraphDistanceMeasure,
+    Distance: FloatingPoint,
     Mailboxes: MailboxesProtocol
   >(
     startingAt startVertex: VertexId,
@@ -571,29 +562,55 @@ where
   where
     Mailboxes.Mailbox.Graph == ParallelProjection,
     ParallelProjection: IncidenceGraph,
+    Vertex.Distance == Distance,
     Mailboxes.Mailbox.Message == DistanceSearchMessage<VertexId, Distance>
   {
-    computeBFS(startingAt: [startVertex], using: &mailboxes)
+    computeBFS(startingAt: [startVertex], effectivelyInfinite: Distance.infinity, using: &mailboxes)
   }
 
   /// Executes breadth first search in parallel.
   ///
   /// Note: distances are not kept track of during BFS; at the conclusion of this algorithm,
-  /// the `vertex.distance` will be `.zero` if it's reachable, and `.effectiveInfinity` otherwise.
+  /// the `vertex.distance` will be `.zero` if it's reachable, and `effectivelyInfinite` otherwise.
   ///
-  /// - Parameter startVerticies: The verticies to begin search at.
+  /// - Parameter startVertex: The verticies to begin search at.
   /// - Returns: the number of steps taken to compute the closure (aka longest path length).
   public mutating func computeBFS<
-    StartCollection: Collection,
-    Distance: GraphDistanceMeasure,
+    Distance: FixedWidthInteger,
     Mailboxes: MailboxesProtocol
   >(
-    startingAt startVerticies: StartCollection,
+    startingAt startVertex: VertexId,
     using mailboxes: inout Mailboxes
   ) -> Int
   where
     Mailboxes.Mailbox.Graph == ParallelProjection,
     ParallelProjection: IncidenceGraph,
+    Vertex.Distance == Distance,
+    Mailboxes.Mailbox.Message == DistanceSearchMessage<VertexId, Distance>
+  {
+    computeBFS(startingAt: [startVertex], effectivelyInfinite: Distance.max, using: &mailboxes)
+  }
+
+  /// Executes breadth first search in parallel.
+  ///
+  /// Note: distances are not kept track of during BFS; at the conclusion of this algorithm,
+  /// the `vertex.distance` will be `.zero` if it's reachable, and `effectivelyInfinite` otherwise.
+  ///
+  /// - Parameter startVerticies: The verticies to begin search at.
+  /// - Returns: the number of steps taken to compute the transitive closure.
+  public mutating func computeBFS<
+    StartCollection: Collection,
+    Distance: AdditiveArithmetic & Comparable,
+    Mailboxes: MailboxesProtocol
+  >(
+    startingAt startVerticies: StartCollection,
+    effectivelyInfinite: Distance,
+    using mailboxes: inout Mailboxes
+  ) -> Int
+  where
+    Mailboxes.Mailbox.Graph == ParallelProjection,
+    ParallelProjection: IncidenceGraph,
+    Vertex.Distance == Distance,
     Mailboxes.Mailbox.Message == DistanceSearchMessage<VertexId, Distance>,
     StartCollection.Element == VertexId
   {
@@ -609,7 +626,7 @@ where
             to: context.destination(of: edge))
         }
       } else {
-        vertex.distance = .effectiveInfinity
+        vertex.distance = effectivelyInfinite
       }
     }
     var stepCount = 1
@@ -619,7 +636,7 @@ where
       step(mailboxes: &mailboxes) { (context, vertex) in
         if let message = context.inbox {
           if vertex.distance == .zero { return }
-          // Transitioning from `.effectiveInfinity` to `.zero`; broadcast to neighbors.
+          // Transitioning from `effectivelyInfinite` to `.zero`; broadcast to neighbors.
           vertex.distance = .zero
           vertex.predecessor = message.predecessor
           for edge in context.edges {
@@ -636,7 +653,6 @@ where
 
 /// Global state used inside `computeShortestPaths`.
 fileprivate struct EarlyStopGlobalState<Distance>: MergeableMessage, DefaultInitializable {
-  // TODO: consider initializing to `effectiveInfinity`?
   /// The distance to the end vertex.
   var endVertexDistance: Distance? = nil
 
@@ -674,13 +690,14 @@ where
   /// - Parameter: maximumSteps: The maximum number of super-steps to take.
   /// - Returns: the number of steps taken to compute the closure (aka longest path length).
   public mutating func computeShortestPaths<
-    Distance: GraphDistanceMeasure,
+    Distance: Comparable & AdditiveArithmetic,
     Mailboxes: MailboxesProtocol,
     DistanceMap: ParallelCapablePropertyMap
   >(
     startingAt startVertex: VertexId,
     stoppingAt stopVertex: VertexId? = nil,
     distances: DistanceMap,
+    effectivelyInfinite: Distance,
     mailboxes: inout Mailboxes,
     maximumSteps: Int? = nil
   ) -> Int
@@ -707,7 +724,7 @@ where
             to: context.destination(of: edge))
         }
       } else {
-        vertex.distance = .effectiveInfinity
+        vertex.distance = effectivelyInfinite
       }
     }
     var globalState = EarlyStopGlobalState<Distance>()

--- a/Tests/PenguinGraphTests/DijkstraSearchTests.swift
+++ b/Tests/PenguinGraphTests/DijkstraSearchTests.swift
@@ -113,7 +113,8 @@ final class DijkstraSearchTests: XCTestCase {
       distancesToVertex: &vertexDistanceMap,
       edgeLengths: edgeWeights,
       workList: [PriorityQueueElement<Int, Int>](),
-      workListIndex: ArrayPriorityQueueIndexer(count: g.vertexCount)
+      workListIndex: ArrayPriorityQueueIndexer(count: g.vertexCount),
+      effectivelyInfinite: Int.max
     ) { e, g in
       recorder.consume(e)
       predecessors.record(e, graph: g)

--- a/Tests/PenguinGraphTests/VertexParallelTests.swift
+++ b/Tests/PenguinGraphTests/VertexParallelTests.swift
@@ -118,7 +118,11 @@ final class VertexParallelTests: XCTestCase {
     let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
     XCTAssertEqual(
       6,
-      g.computeShortestPaths(startingAt: vIds[0], distances: edgeDistanceMap, mailboxes: &mailboxes)
+      g.computeShortestPaths(
+        startingAt: vIds[0],
+        distances: edgeDistanceMap,
+        effectivelyInfinite: Int.max,
+        mailboxes: &mailboxes)
     )
 
     //  -> v0 -> v1 -> v2    v6 (disconnected)
@@ -156,6 +160,7 @@ final class VertexParallelTests: XCTestCase {
       g.computeShortestPaths(
         startingAt: vIds[0],
         distances: edgeDistanceMap,
+        effectivelyInfinite: Int.max,
         mailboxes: &mailboxes,
         maximumSteps: 3))
 
@@ -195,6 +200,7 @@ final class VertexParallelTests: XCTestCase {
         startingAt: vIds[0],
         stoppingAt: vIds[3],
         distances: edgeDistanceMap,
+        effectivelyInfinite: Int.max,
         mailboxes: &mailboxes))
 
     //  -> v0 -> v1 -> v2    v6 (disconnected)
@@ -285,7 +291,10 @@ final class VertexParallelTests: XCTestCase {
       XCTAssertEqual(
         6,
         g.computeShortestPaths(
-          startingAt: vIds[0], distances: edgeDistanceMap, mailboxes: &mailboxes))
+          startingAt: vIds[0],
+          distances: edgeDistanceMap,
+          effectivelyInfinite: Int.max,
+          mailboxes: &mailboxes))
 
       //  -> v0 -> v1 -> v2    v6 (disconnected)
       // |    '--> v3 <--'
@@ -468,7 +477,10 @@ extension VertexParallelTests {
       XCTAssertEqual(
         6,
         g.computeShortestPaths(
-          startingAt: vIds[0], distances: edgeDistanceMap, mailboxes: &mailboxes))
+          startingAt: vIds[0],
+          distances: edgeDistanceMap,
+          effectivelyInfinite: Int.max,
+          mailboxes: &mailboxes))
 
       //  -> v0 -> v1 -> v2    v6 (disconnected)
       // |    '--> v3 <--'


### PR DESCRIPTION
This is a follow-on to https://github.com/saeta/penguin/pull/45.