### PR TITLE
add recursive tuple initializer

### DIFF
--- a/Sources/PenguinStructures/Tuple.swift
+++ b/Sources/PenguinStructures/Tuple.swift
@@ -63,6 +63,12 @@ public struct Tuple<Head, Tail: TupleProtocol>: TupleProtocol {
   
   /// The number of elements
   public static var count: Int { Tail.count + 1 }
+
+  /// Creates a tuple whose first element is `head` and whose remaining elements are `tail`.
+  public init(head: Head, tail: Tail) {
+    self.head = head
+    self.tail = tail
+  }
 }
 
 extension Tuple: DefaultInitializable

--- a/Tests/PenguinStructuresTests/TupleTests.swift
+++ b/Tests/PenguinStructuresTests/TupleTests.swift
@@ -69,6 +69,12 @@ class TupleTests: XCTestCase {
     XCTAssertEqual(Tuple("foo", 0.0, 1).tail, Tuple(0.0, 1))
   }
 
+  func test_recursiveInit() {
+    XCTAssertEqual(Tuple(head: "a", tail: Empty()), Tuple("a"))
+    XCTAssertEqual(Tuple(head: 0, tail: Tuple("a")), Tuple(0, "a"))
+    XCTAssertEqual(Tuple(head: 1.0, tail: Tuple(0, "a")), Tuple(1.0, 0, "a"))
+  }
+
   func test_count() {
     typealias I = Int
     XCTAssertEqual(Tuple0.count, 0)


### PR DESCRIPTION
This is useful for writing functions that "map" an operation over a tuple.

e.g. in SwiftFusion, we have a tuple of variable assignment buffers and a tuple of indices and we need to produce a tuple of variable values. We can do this with a function that indexes the head buffer by the head index and then recursively calls itself on the tails. Then, this function needs to call `Tuple.init(head:tail:)` to produce its result.