### PR TITLE
[Parallel Expander] Support vertices with no in edges.

### DIFF
--- a/Sources/PenguinGraphs/ParallelExpander.swift
+++ b/Sources/PenguinGraphs/ParallelExpander.swift
@@ -283,13 +283,14 @@ extension ParallelGraph where Self: IncidenceGraph, Self.Vertex: LabeledVertex {
 
     // Receive
     step(mailboxes: &mailboxes) { (context, vertex) in
-      assert(
-        context.inbox != nil,
-        """
-        Missing message for \(context.vertex) (\(vertex)); are there no edges coming into this \
-        vertex?
-        """)
-      vertex.totalIncomingEdgeWeight = context.inbox!.value
+      if let incomingSum = context.inbox {
+        vertex.totalIncomingEdgeWeight = incomingSum.value
+      } else {
+        // This is safe (i.e. doesn't trigger a division by 0) because the calculation occurs only
+        /// when there's incoming messages.
+        vertex.totalIncomingEdgeWeight = 0  
+      }
+      vertex.computedLabels = vertex.seedLabels
     }
   }
 

--- a/Tests/PenguinGraphTests/ParallelExpanderTests.swift
+++ b/Tests/PenguinGraphTests/ParallelExpanderTests.swift
@@ -46,8 +46,32 @@ final class ParallelExpanderTests: XCTestCase {
     assertClose(0.25, g[vertex: v2].computedLabels[1]!)
     assertClose(-0.25, g[vertex: v2].computedLabels[2]!)
   }
+
+  func testVertexWithNoInEdges() {
+    var g = Graph()
+    let v1 = g.addVertex(storing: TestLabeledVertex(seedLabels: [1, 0, -1]))
+    let v2 = g.addVertex()
+    let v3 = g.addVertex(storing: TestLabeledVertex(seedLabels: [-1, 1, 0]))
+
+    let e1 = g.addEdge(from: v1, to: v2)
+    let e2 = g.addEdge(from: v3, to: v2)
+
+    let propertyMap = EdgeWeights([e1: 0.5, e2: 0.5])
+
+    var mb1 = PerThreadMailboxes(for: g, sending: IncomingEdgeWeightSumMessage.self)
+    g.computeIncomingEdgeWeightSum(using: &mb1, propertyMap)
+
+    var mb2 = PerThreadMailboxes(for: g, sending: LabelBundle.self)
+    g.propagateLabels(m1: 1.0, m2: 0.01, m3: 0.01, using: &mb2, propertyMap, maxStepCount: 10)
+
+    assertClose(0, g[vertex: v2].computedLabels[0]!)
+    assertClose(0.25, g[vertex: v2].computedLabels[1]!)
+    assertClose(-0.25, g[vertex: v2].computedLabels[2]!)
+  }
+
   static var allTests = [
-    ("testSimple", testSimple)
+    ("testSimple", testSimple),
+    ("testVertexWithNoInEdges", testVertexWithNoInEdges),
   ]
 }
 

--- a/Tests/PenguinGraphTests/ParallelExpanderTests.swift
+++ b/Tests/PenguinGraphTests/ParallelExpanderTests.swift
@@ -67,6 +67,14 @@ final class ParallelExpanderTests: XCTestCase {
     assertClose(0, g[vertex: v2].computedLabels[0]!)
     assertClose(0.25, g[vertex: v2].computedLabels[1]!)
     assertClose(-0.25, g[vertex: v2].computedLabels[2]!)
+
+    XCTAssertEqual(1, g[vertex: v1].computedLabels[0]!)
+    XCTAssertEqual(0, g[vertex: v1].computedLabels[1]!)
+    XCTAssertEqual(-1, g[vertex: v1].computedLabels[2]!)
+
+    XCTAssertEqual(-1, g[vertex: v3].computedLabels[0]!)
+    XCTAssertEqual(1, g[vertex: v3].computedLabels[1]!)
+    XCTAssertEqual(0, g[vertex: v3].computedLabels[2]!)
   }
 
   static var allTests = [


### PR DESCRIPTION
This modification extends the expander algorithm family to support
graphs that contain vertices with no incoming edges. (Previously,
the presence of these vertices would trigger assertion failures.)