### PR TITLE
Random sampling follow-on's.

### DIFF
--- a/Sources/PenguinStructures/Random.swift
+++ b/Sources/PenguinStructures/Random.swift
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extension RandomAccessCollection where Index == Int {
+extension RandomAccessCollection {
+  /// Returns `k` randomly chosen elements, such that each element is chosen at most once.
   public func randomSelectionWithoutReplacement<Randomness: RandomNumberGenerator>(
     k: Int,
     using randomness: inout Randomness
@@ -38,12 +39,19 @@ extension RandomAccessCollection where Index == Int {
         }
         prev = v
       }
-      if ok { return tmp.map { self[Index($0)] } }
+      if ok { return tmp.map { self[index(startIndex, offsetBy: $0)] } }
     }
+  }
+
+  /// Returns `k` randomly chosen elements, such that each element is chosen at most once.
+  public func randomSelectionWithoutReplacement(k: Int) -> [Element] {
+    var g = SystemRandomNumberGenerator()
+    return randomSelectionWithoutReplacement(k: k, using: &g)
   }
 }
 
 extension Collection {
+  /// Returns `k` randomly chosen elements, such that each element is chosen at most once.
   public func randomSelectionWithoutReplacement<Randomness: RandomNumberGenerator>(
     k: Int,
     using randomness: inout Randomness
@@ -70,6 +78,7 @@ extension Collection {
     fatalError("Should not have reached here: \(self), \(selected)")
   }
 
+  /// Returns `k` randomly chosen elements, such that each element is chosen at most once.
   public func randomSelectionWithoutReplacement(k: Int) -> [Element] {
     var g = SystemRandomNumberGenerator()
     return randomSelectionWithoutReplacement(k: k, using: &g)

--- a/Tests/PenguinStructuresTests/RandomTests.swift
+++ b/Tests/PenguinStructuresTests/RandomTests.swift
@@ -16,7 +16,7 @@ import PenguinStructures
 import XCTest
 
 final class RandomTests: XCTestCase {
-  func testRandomSelectionWithoutReplacement() {
+  func testRandomSelectionWithoutReplacementRandomAccessCollection() {
     XCTAssertEqual(Array(0..<10), (0..<10).randomSelectionWithoutReplacement(k: 10))
     XCTAssertEqual([], (0..<Int.max).randomSelectionWithoutReplacement(k: 0))
     XCTAssertEqual(2, (0..<42_000).randomSelectionWithoutReplacement(k: 2).count)
@@ -27,9 +27,34 @@ final class RandomTests: XCTestCase {
       let selection = (0..<42_000).randomSelectionWithoutReplacement(k: 100)
       XCTAssertEqual(k, Set(selection).count, "\(selection)")
     }
+
+    do {
+      let k = 5
+      var selection = (0..<1100)[1000...].randomSelectionWithoutReplacement(k: k)
+      selection.sort()
+      XCTAssertEqual(k, selection.count)
+      XCTAssert(selection[0] >= 1000, "\(selection)")
+      XCTAssert(selection[0] <= 1100, "\(selection)")
+      XCTAssertEqual(k, Set(selection).count)
+    }
+  }
+
+  func testRandomSelectionWithoutReplacementCollection() {
+    // We use set as our non-random access collection.
+    XCTAssertEqual(Array(0..<10), Set(0..<10).randomSelectionWithoutReplacement(k: 10).sorted())
+    XCTAssertEqual([], Set(0..<100_000).randomSelectionWithoutReplacement(k: 0))
+    XCTAssertEqual(2, Set(0..<42_000).randomSelectionWithoutReplacement(k: 2).count)
+    XCTAssertEqual(Array(0..<100), Set(0..<100).randomSelectionWithoutReplacement(k: 1000).sorted())
+
+    do {
+      let k = 100
+      let selection = Set(0..<42_000).randomSelectionWithoutReplacement(k: k)
+      XCTAssertEqual(k, Set(selection).count, "\(selection)")
+    }
   }
 
   static var allTests = [
-    ("testRandomSelectionWithoutReplacement", testRandomSelectionWithoutReplacement),
+    ("testRandomSelectionWithoutReplacementRandomAccessCollection", testRandomSelectionWithoutReplacementRandomAccessCollection),
+    ("testRandomSelectionWithoutReplacementCollection", testRandomSelectionWithoutReplacementCollection),
   ]
 }


### PR DESCRIPTION
This PR adds:
 - Doc comments
 - Exposes the convenience method on RAC (otherwise the fast impl isn't
   called on RAC's)
 - Generalizes to all RAC's.