### PR TITLE
More work refactoring [Any]Array[Storage|Buffer] to avoid dynamic dispatch

### DIFF
--- a/Sources/PenguinStructures/AnyArrayBuffer.swift
+++ b/Sources/PenguinStructures/AnyArrayBuffer.swift
@@ -95,12 +95,9 @@ extension AnyArrayBuffer {
   /// - Complexity: Amortized O(1).
   /// - Precondition: `type(of: x) == elementType`
   public mutating func append<T>(_ x: T) -> Int {
-    assert(type(of: x) == elementType)
     let isUnique = isKnownUniquelyReferenced(&storage)
-    return withUnsafePointer(to: x) {
-      if isUnique, let r = storage.appendValue(at: .init($0)) { return r }
-      storage = storage.appendingValue(at: .init($0), moveElements: isUnique)
-      return count - 1
-    }
+    if isUnique, let r = storage.unsafelyAppend(x) { return r }
+    storage = storage.unsafelyAppending(x, moveElements: isUnique)
+    return count - 1
   }
 }

--- a/Sources/PenguinStructures/AnyArrayBuffer.swift
+++ b/Sources/PenguinStructures/AnyArrayBuffer.swift
@@ -55,6 +55,23 @@ public struct AnyArrayBuffer<Storage: AnyArrayStorage> {
     return storage.withUnsafeMutableBufferPointer(assumingElementType: T.self, body)
   }
 
+  /// Accesses the `i`th element.
+  ///
+  /// - Requires: `elementType == Element.self``
+  public func subscript<Element>(
+    i: Int,
+    assumingElementType _: Element.Type = Element.self,
+  ) -> Element {
+    read_ {
+      yield withUnsafeBufferPointer(assumingElementType: Element.self) { $0[i] }
+    }
+    modify_ {
+      defer { _fixLifetime(self) }
+      yield &withUnsafeMutableBufferPointer(
+        assumingElementType: Element.self)[i]
+    }
+  }
+
   /// Returns the result of calling `body` on the elements of `self`.
   public func withUnsafeRawPointerToElements<R>(
     body: (UnsafeRawPointer)->R


### PR DESCRIPTION
Preparing for SwiftFusion migration, will come back to strip out raw pointer operations and update tests.