### PR TITLE
Add `UnionEdgeGraph`, `Either`, `ConcatenatedCollection` and `MutableGraph.addEdges`

### DIFF
--- a/Sources/PenguinGraphs/GraphCopying.swift
+++ b/Sources/PenguinGraphs/GraphCopying.swift
@@ -165,3 +165,27 @@ extension MutablePropertyGraph where Self: DefaultInitializable {
       edgeProperties: InternalEdgePropertyMap(for: other))
   }
 }
+
+extension IncidenceGraph where Self: MutableGraph & VertexListGraph {
+  /// Adds all edges from `other` into `self`.
+  public mutating func addEdges<Other: IncidenceGraph>(from other: Other)
+  where Other.VertexId == VertexId {
+    for v in vertices {
+      for e in other.edges(from: v) {
+        _ = addEdge(from: v, to: other.destination(of: e))
+      }
+    }
+  }
+}
+
+extension IncidenceGraph where Self: MutablePropertyGraph & VertexListGraph {
+  /// Adds all edges from `other` into `self`.
+  public mutating func addEdges<Other: IncidenceGraph & PropertyGraph>(from other: Other)
+  where Other.VertexId == VertexId, Other.Edge == Edge {
+    for v in vertices {
+      for e in other.edges(from: v) {
+        _ = addEdge(from: v, to: other.destination(of: e), storing: other[edge: e])
+      }
+    }
+  }
+}

--- a/Sources/PenguinGraphs/GraphTransformations.swift
+++ b/Sources/PenguinGraphs/GraphTransformations.swift
@@ -456,8 +456,6 @@ where Base.VertexId == ExtraEdges.VertexId {
     ConcatenatedCollection<
       LazyMapCollection<Base.VertexEdgeCollection, EdgeId>,
       LazyMapCollection<ExtraEdges.VertexEdgeCollection, EdgeId>>
-  // public typealias VertexEdgeCollection =
-  //   ConcatenatedCollection<[EdgeId], [EdgeId]>
 
   /// A collection of edges from a single vertex.
   public func edges(from vertex: VertexId) -> VertexEdgeCollection {

--- a/Sources/PenguinGraphs/GraphTransformations.swift
+++ b/Sources/PenguinGraphs/GraphTransformations.swift
@@ -415,3 +415,78 @@ extension BidirectionalGraph {
     TransposeGraph(self)
   }
 }
+
+// TODO: consider generalizing to EdgeListGraph's.
+
+/// A graph containing all the vertices and edges of a base graph, augmented with all the edges of
+/// a second graph data structure.
+///
+/// A `UnionEdgesGraph` allows overlaying the edges of one graph onto the edges of another graph.
+/// This operation can be useful when viewing the same set of vertices in multiple ways. The
+/// `UnionEdgesGraph` does not modify or even copy either of the two underlying graphs, and all
+/// operations on the `UnionEdgesGraph` occur with identical complexity to the underlying graphs'
+/// operations.
+///
+/// Note: If many operations will be done on the resulting graph, it can sometimes be more efficient
+/// to flatten the extra edges into the base graph (so long as `Base` is a `MutableGraph`) by
+/// calling `base.addEdges(from: extraEdges)`.
+///
+/// Beware: it is up to the user to ensure that all edges in `ExtraEdges` point to valid vertices in
+/// `Base`, and that `ExtraEdges.edges(from:)` can be called with every valid vertex in `Base`.
+// public struct UnionEdgesGraph<Base: IncidenceGraph, ExtraEdges: IncidenceGraph>: IncidenceGraph
+// where Base.VertexId == ExtraEdges.VertexId {
+//   /// The name of a vertex in `self`.
+//   public typealias VertexId = Base.VertexId
+//   /// The name of an edge in `self`.
+//   public enum EdgeId: Equatable, Comparable {
+//     case base(Base.EdgeId)
+//     case extra(ExtraEdges.EdgeId)
+
+//     /// Returns true if `lhs` should be ordered before `rhs`.
+//     public static func < (lhs: Self, rhs: Self) -> Bool {
+//       switch (lhs, rhs) {
+//       case (.base(let lhs), .base(let rhs)): return lhs < rhs
+//       case (.base, _): return true
+//       case (.extra(let lhs), .extra(let rhs)): return lhs < rhs
+//       default: return false
+//       }
+//     }
+//   }
+
+//   /// The base graph.
+//   private var base: Base
+//   /// A graph containing extra edges.
+//   private var extraEdges: ExtraEdges
+
+//   /// Creates a graph based on `base`, augmented with edges in `extraEdges`.
+//   public init(_ base: Base, _ extraEdges: ExtraEdges) {
+//     self.base = base
+//     self.extraEdges = extraEdges
+//   }
+
+//   /// A collection of edges from a single vertex.
+//   public struct VertexEdgeCollection: Collection {
+//     let base: Base.VertexEdgeCollection
+//     let extra: ExtraEdges.VertexEdgeCollection
+
+//     public enum Index {
+      
+//     }
+
+//     public var startIndex: 
+//   }
+//   public func edges(from vertex: VertexId) -> VertexEdgeCollection {
+//     VertexEdgeCollection(base: base.edges(from: vertex), extra: extraEdges.edges(from: vertex))
+//   }
+// }
+
+// extension UnionEdgesGraph.EdgeId: Hashable
+// where BaseGraph.EdgeId: Hashable, ExtraEdges.EdgeId: Hashable {
+//   /// Hashes `self` into `hasher`.
+//   public func hash(into hasher: inout Hasher) {
+//     switch self {
+//     case .base(let edge): edge.hash(into: &hasher)
+//     case .extra(let edge): edge.hash(into: &hasher)
+//     }
+//   }
+// }

--- a/Sources/PenguinStructures/ConcatenatedCollection.swift
+++ b/Sources/PenguinStructures/ConcatenatedCollection.swift
@@ -1,0 +1,113 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/// A collection that is all the elements of one collection followed by all the elements of a second
+/// collection.
+public struct ConcatenatedCollection<First: Collection, Second: Collection>: Collection where
+First.Element == Second.Element {
+  /// The elements in `self`.
+  public typealias Element = First.Element
+  /// The collection whose elements appear first.
+  private var first: First
+  /// The collection whose elements appear second.
+  private var second: Second
+
+  /// Concatenates `first` with `second`.
+  public init(_ first: First, _ second: Second) {
+    self.first = first
+    self.second = second
+  }
+
+  /// A handle into elements in `self`.
+  public enum Index: Equatable, Comparable {
+    case first(First.Index)
+    case second(Second.Index)
+
+    /// Returns true if `lhs` should be ordered before `rhs`.
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      switch (lhs, rhs) {
+      case (.first(let lhs), .first(let rhs)): return lhs < rhs
+      case (.first, _): return true
+      case (.second(let lhs), .second(let rhs)): return lhs < rhs
+      default: return false
+      }
+    }
+  }
+
+  /// The first valid index into `self`.
+  public var startIndex: Index { .first(first.startIndex) }
+  /// One beyond the last valid index into `self`.
+  public var endIndex: Index { .second(second.endIndex) }
+  /// Returns the next valid index after `index`.
+  public func index(after index: Index) -> Index {
+    switch index {
+    case .first(let index):
+      let newIndex = first.index(after: index)
+      guard newIndex != first.endIndex else { return .second(second.startIndex) }
+      return .first(newIndex)
+    case .second(let index):
+      return .second(second.index(after: index))
+    }
+  }
+  /// Accesses element at `index`.
+  public subscript(index: Index) -> Element {
+    switch index {
+    case .first(let index): return first[index]
+    case .second(let index): return second[index]
+    }
+  }
+  /// The number of elements in `self`.
+  public var count: Int { first.count + second.count }
+  /// True if `self` contains no elements.
+  public var isEmpty: Bool { first.isEmpty && second.isEmpty }
+}
+
+extension ConcatenatedCollection.Index: Hashable where First.Index: Hashable, Second.Index: Hashable {
+  /// Hashes `self` into `hasher`.
+  public func hash(into hasher: inout Hasher) {
+    switch self {
+    case .first(let i): i.hash(into: &hasher)
+    case .second(let i): i.hash(into: &hasher)
+    }
+  }
+}
+
+extension ConcatenatedCollection: BidirectionalCollection
+where First: BidirectionalCollection, Second: BidirectionalCollection {
+  /// Returns the next valid index before `index`.
+  public func index(before index: Index) -> Index {
+    switch index {
+    case .first(let index): return .first(first.index(before: index))
+    case .second(let index):
+      if index == second.startIndex {
+        return .first(first.index(before: first.endIndex))
+      }
+      return .second(second.index(before: index))
+    }
+  }
+}
+
+// TODO: Add RandomAccessCollection conformance.
+// TODO: Add MutableCollection conformance.
+
+extension Collection {
+  /// Returns a new collection where all the elements of `self` appear before all the elements of
+  /// `other`.
+  public func concatenated<Other: Collection>(with other: Other)
+  -> ConcatenatedCollection<Self, Other>
+  where Other.Element == Element {
+    return ConcatenatedCollection(self, other)
+  }
+}

--- a/Sources/PenguinStructures/DefaultInitializable.swift
+++ b/Sources/PenguinStructures/DefaultInitializable.swift
@@ -21,3 +21,9 @@ public protocol DefaultInitializable {
 extension Array: DefaultInitializable {}
 extension Dictionary: DefaultInitializable {}
 extension String: DefaultInitializable {}
+extension Int: DefaultInitializable {}
+extension UInt: DefaultInitializable {}
+extension Int32: DefaultInitializable {}
+extension UInt32: DefaultInitializable {}
+extension Float: DefaultInitializable {}
+extension Double: DefaultInitializable {}

--- a/Sources/PenguinStructures/Either.swift
+++ b/Sources/PenguinStructures/Either.swift
@@ -1,0 +1,50 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Represents one of two possible choices.
+public enum Either<A, B> {
+  case a(A)
+  case b(B)
+}
+
+extension Either: Equatable where A: Equatable, B: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.a(let lhs), .a(let rhs)): return lhs == rhs
+    case (.b(let lhs), .b(let rhs)): return lhs == rhs
+    default: return false
+    }
+  }
+}
+
+extension Either: Comparable where A: Comparable, B: Comparable {
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.a(let lhs), .a(let rhs)): return lhs < rhs
+    case (.a, _): return true
+    case (.b(let lhs), .b(let rhs)): return lhs < rhs
+    default: return false
+    }
+  }
+}
+
+
+extension Either: Hashable where A: Hashable, B: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    switch self {
+    case .a(let a): a.hash(into: &hasher)
+    case .b(let b): b.hash(into: &hasher)
+    }
+  }
+}

--- a/Sources/PenguinStructures/Either.swift
+++ b/Sources/PenguinStructures/Either.swift
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Represents one of two possible choices.
+/// Represents one of two possible cases.
 public enum Either<A, B> {
   case a(A)
   case b(B)
 }
 
 extension Either: Equatable where A: Equatable, B: Equatable {
+  /// True if `lhs` is equivalent to `rhs`.
   public static func == (lhs: Self, rhs: Self) -> Bool {
     switch (lhs, rhs) {
     case (.a(let lhs), .a(let rhs)): return lhs == rhs
@@ -29,6 +30,7 @@ extension Either: Equatable where A: Equatable, B: Equatable {
 }
 
 extension Either: Comparable where A: Comparable, B: Comparable {
+  /// True iff `lhs` is less than `rhs`.
   public static func < (lhs: Self, rhs: Self) -> Bool {
     switch (lhs, rhs) {
     case (.a(let lhs), .a(let rhs)): return lhs < rhs
@@ -41,6 +43,7 @@ extension Either: Comparable where A: Comparable, B: Comparable {
 
 
 extension Either: Hashable where A: Hashable, B: Hashable {
+  /// Hashes `self` into `hasher`.
   public func hash(into hasher: inout Hasher) {
     switch self {
     case .a(let a): a.hash(into: &hasher)

--- a/Tests/PenguinGraphTests/GraphCopyingTests.swift
+++ b/Tests/PenguinGraphTests/GraphCopyingTests.swift
@@ -111,9 +111,40 @@ final class GraphCopyingTests: XCTestCase {
     XCTAssertEqual(2, dst.inDegree(of: 2))
   }
 
+  func testAddingEdges() {
+    var src = DirectedAdjacencyList<String, String, Int>()
+    _ = src.addVertex()
+    _ = src.addVertex()
+    _ = src.addVertex()
+
+    _ = src.addEdge(from: 1, to: 2, storing: "1->2 (src)")
+
+    var dst = UndirectedAdjacencyList<String, String, Int>()
+    _ = dst.addVertex()
+    _ = dst.addVertex()
+    _ = dst.addVertex()
+
+    _ = dst.addEdge(from: 0, to: 1, storing: "0->1 (dst)")
+    var edgeCallback = false
+    dst.addEdges(from: src) { e, g in
+      XCTAssertFalse(edgeCallback)
+      edgeCallback = true
+      XCTAssertEqual(1, g.source(of: e))
+      XCTAssertEqual(2, g.destination(of: e))
+    }
+    XCTAssert(edgeCallback)
+
+    let edges = dst.edges(from: 2)
+    XCTAssertEqual(1, edges.count)
+    XCTAssertEqual(2, dst.source(of: edges[0]))
+    XCTAssertEqual(1, dst.destination(of: edges[0]))
+    XCTAssertEqual("1->2 (src)", dst[edge: edges[0]])
+  }
+
   static var allTests = [
     ("testUndirectedCopying", testUndirectedCopying),
     ("testProperyGraphCopying", testProperyGraphCopying),
     ("testProperyGraphCopyingBidirectional", testProperyGraphCopyingBidirectional),
+    ("testAddingEdges", testAddingEdges),
   ]
 }

--- a/Tests/PenguinGraphTests/GraphTransformationsTests.swift
+++ b/Tests/PenguinGraphTests/GraphTransformationsTests.swift
@@ -1,0 +1,48 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+import PenguinGraphs
+import XCTest
+
+final class GraphTransformationsTests: XCTestCase {
+
+  func testUnionEdges() {
+    var g1 = BidirectionalAdjacencyList<Int, String, Int>()
+    _ = g1.addVertex(storing: 10)
+    _ = g1.addVertex(storing: 11)
+    _ = g1.addVertex(storing: 12)
+    _ = g1.addEdge(from: 0, to: 1, storing: "0->1 (g1)")
+
+    var g2 = BidirectionalAdjacencyList<Empty, String, Int>()
+    _ = g2.addVertex()
+    _ = g2.addVertex()
+    _ = g2.addVertex()
+    _ = g2.addEdge(from: 1, to: 2, storing: "1->2 (g2)")
+
+    var g = g1.unionEdges(with: g2)
+
+    XCTAssertEqual(3, g.vertexCount)
+    XCTAssertEqual(Array(0..<3), Array(g.vertices))
+    XCTAssertEqual(Array(10..<13), g.vertices.map { g[vertex: $0] })
+
+    var recorder = TablePredecessorRecorder(for: g)
+    g.breadthFirstSearch(startingAt: 0) { recorder.record($0, graph: $1) }
+    XCTAssertEqual([0, 1, 2], Array(recorder.path(to: 2)!))
+  }
+
+  static var allTests = [
+    ("testUnionEdges", testUnionEdges),
+  ]
+}

--- a/Tests/PenguinGraphTests/XCTestManifests.swift
+++ b/Tests/PenguinGraphTests/XCTestManifests.swift
@@ -26,6 +26,7 @@ import XCTest
       testCase(EdgeInfoTests.allTests),
       testCase(GraphCopyingTests.allTests),
       testCase(GraphGeneratorsTests.allTests),
+      testCase(GraphTransformationsTests.allTests),
       testCase(InfiniteGridTests.allTests),
       testCase(InternalPropertyMapTests.allTests),
       testCase(ParallelExpanderTests.allTests),

--- a/Tests/PenguinStructuresTests/ConcatenatedCollectionTests.swift
+++ b/Tests/PenguinStructuresTests/ConcatenatedCollectionTests.swift
@@ -1,0 +1,44 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinStructures
+import XCTest
+
+final class ConcatenatedCollectionTests: XCTestCase {
+
+  func testConcatenateSetAndList() {
+    let c = Set(["1", "2", "3"]).concatenated(with: ["10", "11", "12"])
+    XCTAssertFalse(c.isEmpty)
+    XCTAssertEqual(6, c.count)
+    XCTAssertEqual(Set(["1", "2", "3"]), Set(c.prefix(3)))
+    XCTAssertEqual(["10", "11", "12"], Array(c.suffix(3)))
+  }
+
+  func testConcatenateRanges() {
+    let c = (0..<3).concatenated(with: 3...6)
+    XCTAssertEqual(Array(0...6), Array(c))    
+  }
+
+  func testConcatenateBidirectionalOperations() {
+    let c = (0..<3).concatenated(with: [10, 11, 12])
+    XCTAssertEqual(6, c.count)
+    XCTAssertEqual([12, 11, 10, 2, 1, 0], Array(c.reversed()))
+  }
+
+  static var allTests = [
+    ("testConcatenateSetAndList", testConcatenateSetAndList),
+    ("testConcatenateRanges", testConcatenateRanges),
+    ("testConcatenateBidirectionalOperations", testConcatenateBidirectionalOperations),
+  ]
+}

--- a/Tests/PenguinStructuresTests/ConcatenatedCollectionTests.swift
+++ b/Tests/PenguinStructuresTests/ConcatenatedCollectionTests.swift
@@ -36,9 +36,16 @@ final class ConcatenatedCollectionTests: XCTestCase {
     XCTAssertEqual([12, 11, 10, 2, 1, 0], Array(c.reversed()))
   }
 
+  func testConcatenatingEmpty() {
+    let c = (0..<0).concatenated(with: [1, 2, 3])
+    XCTAssertEqual(3, c.count)
+    XCTAssertEqual([1, 2, 3], Array(c))
+  }
+
   static var allTests = [
     ("testConcatenateSetAndList", testConcatenateSetAndList),
     ("testConcatenateRanges", testConcatenateRanges),
     ("testConcatenateBidirectionalOperations", testConcatenateBidirectionalOperations),
+    ("testConcatenatingEmpty", testConcatenatingEmpty),
   ]
 }

--- a/Tests/PenguinStructuresTests/EitherTests.swift
+++ b/Tests/PenguinStructuresTests/EitherTests.swift
@@ -1,0 +1,39 @@
+//******************************************************************************
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import PenguinStructures
+
+
+class EitherTests: XCTestCase {
+  
+  func testEquality() {
+    XCTAssertEqual(Either<Int, String>.a(1), .a(1))
+    XCTAssertNotEqual(Either.a(1), .b(1))
+    XCTAssertNotEqual(Either.a(1), .b("1"))
+    XCTAssertEqual(Either<Int, String>.b("0"), .b("0"))
+  }
+
+  func testComparable() {
+    typealias E = Either<Int, Int>
+    XCTAssert(E.a(1) < .b(0))
+    XCTAssert(E.b(0) > .a(100000))
+  }
+
+  static var allTests = [
+    ("testEquality", testEquality),
+    ("testComparable", testComparable),
+  ]
+}

--- a/Tests/PenguinStructuresTests/XCTestManifests.swift
+++ b/Tests/PenguinStructuresTests/XCTestManifests.swift
@@ -26,6 +26,7 @@ import XCTest
       testCase(ConcatenatedCollectionTests.allTests),
       testCase(DequeTests.allTests),
       testCase(DoubleEndedBufferTests.allTests),
+      testCase(EitherTests.allTests),
       testCase(FactoryInitializableTests.allTests),
       testCase(FixedSizeArrayTests.allTests),
       testCase(TupleTests.allTests),

--- a/Tests/PenguinStructuresTests/XCTestManifests.swift
+++ b/Tests/PenguinStructuresTests/XCTestManifests.swift
@@ -23,6 +23,7 @@ import XCTest
       testCase(ArrayStorageExtensionTests.allTests),
       testCase(ArrayStorageTests.allTests),
       testCase(CollectionAlgorithmTests.allTests),
+      testCase(ConcatenatedCollectionTests.allTests),
       testCase(DequeTests.allTests),
       testCase(DoubleEndedBufferTests.allTests),
       testCase(FactoryInitializableTests.allTests),


### PR DESCRIPTION
This PR adds functionality to make it easy to combine the edges of 2 graphs, and the supporting functionality to implement this capability.

There are 2 ways to combine the edges of 2 graphs:

 1. **Modify `self`**: in this mechanism, we modify `self` to copy the edge information into a `MutableGraph`.
 2. **Make a new graph**: in this mechanism, we return a new graph that represents the union of edge sets of the two.

In order to implement the latter, we need to be able to construct a collection that is the concatenation of two underlying collections. This is a general pattern, and thus this is extracted and made generic in the `ConcatenatedCollection` type.

A previous iteration of the `ConcatenatedCollection` used a specialized `Index` type as a nested enum of the `ConcatenatedCollection`. Unfortunately, this makes it impossible to use `ConcatenatedCollection` for `UnionEdgesGraph`, as the `EdgeId` type must work for both `VertexEdgeCollection` and `VertexInEdgeCollection`. As a result, we pull that out, and use `Either`, which solves the problem!
