### PR TITLE
Use Type<T>() instead of T.self

### DIFF
--- a/Sources/Benchmarks/ParallelExpanderBenchmarks.swift
+++ b/Sources/Benchmarks/ParallelExpanderBenchmarks.swift
@@ -44,10 +44,12 @@ let parallelExpander = BenchmarkSuite(name: "ParallelExpander") { suite in
 
       let propertyMap = EdgeWeights(edgeWeightsDict)
 
-      var mb1 = PerThreadMailboxes(for: g, sending: IncomingEdgeWeightSumMessage.self)
+      var mb1 = PerThreadMailboxes(
+        for: g, sending: Type<IncomingEdgeWeightSumMessage>())
+      
       g.computeIncomingEdgeWeightSum(using: &mb1, propertyMap)
 
-      var mb2 = PerThreadMailboxes(for: g, sending: LabelBundle.self)
+      var mb2 = PerThreadMailboxes(for: g, sending: Type<LabelBundle>())
       g.propagateLabels(m1: 1.0, m2: 0.01, m3: 0.01, using: &mb2, propertyMap, maxStepCount: 10)
     }
   }
@@ -71,10 +73,12 @@ let parallelExpander = BenchmarkSuite(name: "ParallelExpander") { suite in
 
       let propertyMap = EdgeWeights(edgeWeightsDict)
 
-      var mb1 = PerThreadMailboxes(for: g, sending: IncomingEdgeWeightSumMessage.self)
+      var mb1 = PerThreadMailboxes(
+        for: g, sending: Type<IncomingEdgeWeightSumMessage>())
+      
       g.computeIncomingEdgeWeightSum(using: &mb1, propertyMap)
 
-      var mb2 = PerThreadMailboxes(for: g, sending: LabelBundle.self)
+      var mb2 = PerThreadMailboxes(for: g, sending: Type<LabelBundle>())
       g.propagateLabels(m1: 1.0, m2: 0.01, m3: 0.01, using: &mb2, propertyMap, maxStepCount: 10)
     }
   }

--- a/Sources/PenguinGraphs/VertexParallelProtocols.swift
+++ b/Sources/PenguinGraphs/VertexParallelProtocols.swift
@@ -150,7 +150,10 @@ public struct SequentialMailboxes<
   /// Initialize mailboxes for `graph` for `messageType` messages.
   ///
   /// This initializer helps the type inference algorithm along.
-  public init<SequentialGraph: ParallelGraph & VertexListGraph>(for graph: __shared SequentialGraph, sending messageType: Message.Type) where SequentialGraph.ParallelProjection == Graph {
+  public init<SequentialGraph: ParallelGraph & VertexListGraph>(
+    for graph: __shared SequentialGraph,
+    sending messageType: Type<Message> = .init()
+  ) where SequentialGraph.ParallelProjection == Graph {
     self.init(vertexCount: graph.vertexCount)
   }
 }
@@ -295,7 +298,10 @@ public class PerThreadMailboxes<
   /// Initialize mailboxes for `graph` for `messageType` messages.
   ///
   /// This initializer helps the type inference algorithm along.
-  public convenience init<SequentialGraph: VertexListGraph & ParallelGraph>(for graph: __shared SequentialGraph, sending messageType: Message.Type) where SequentialGraph.ParallelProjection == Graph {
+  public convenience init<SequentialGraph: VertexListGraph & ParallelGraph>(
+    for graph: __shared SequentialGraph,
+    sending messageType: Type<Message> = .init()
+  ) where SequentialGraph.ParallelProjection == Graph {
     self.init(vertexCount: graph.vertexCount, threadCount: ComputeThreadPools.maxParallelism)
   }
 }

--- a/Sources/PenguinParallel/ConcurrencyPlatform.swift
+++ b/Sources/PenguinParallel/ConcurrencyPlatform.swift
@@ -172,7 +172,7 @@ public struct TypedThreadLocalStorage<Underlying: RawThreadLocalStorage> {
   }
 
   /// Allocates a key for type `T`.
-  public static func makeKey<T: AnyObject>(for type: T.Type) -> Key<T> {
+  public static func makeKey<T: AnyObject>(for _: Type<T>) -> Key<T> {
     Key(key: Underlying.makeKey())
   }
 

--- a/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
+++ b/Sources/PenguinParallel/NonblockingThreadPool/NonBlockingThreadPool.swift
@@ -75,7 +75,7 @@ public class NonBlockingThreadPool<Environment: ConcurrencyPlatform>: ComputeThr
   var threads: [Environment.Thread]
 
   private let perThreadKey = Environment.ThreadLocalStorage.makeKey(
-    for: PerThreadState<Environment>.self)
+    for: Type<PerThreadState<Environment>>())
 
   /// Initialize a new thread pool with `threadCount` threads using threading environment
   /// `environment`.

--- a/Sources/PenguinParallel/ThreadPool.swift
+++ b/Sources/PenguinParallel/ThreadPool.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import struct PenguinStructures.Type
+
 /// Allows efficient use of multi-core CPUs by managing a fixed-size collection of threads.
 ///
 /// From first-principles, a (CPU) compute-bound application will run at peak performance when
@@ -225,7 +227,7 @@ extension ComputeThreadPools {
     }
   }
   /// A key used to index into the thread local storage.
-  private static let threadLocalKey = TLS.makeKey(for: ThreadPoolHolder.self)
+  private static let threadLocalKey = TLS.makeKey(for: Type<ThreadPoolHolder>())
 
   /// A thread local `ComputeThreadPool`.
   ///

--- a/Sources/PenguinPipeline/Pipeline/GeneratorPipelineIterator.swift
+++ b/Sources/PenguinPipeline/Pipeline/GeneratorPipelineIterator.swift
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import struct PenguinStructures.Type
+
 public struct FunctionGeneratorPipelineIterator<T>: PipelineIteratorProtocol {
   public typealias Element = T
   public typealias GenFunc = () throws -> T?
@@ -40,7 +42,9 @@ extension PipelineIterator {
   ///
   /// Note: if the function is expected to be expensive, it's often a good idea to call `.prefetch()`
   /// on the returned iterator.
-  public static func fromFunction<T>(_ typeHint: T.Type, _ function: @escaping () throws -> T?)
+  public static func fromFunction<T>(
+    _: Type<T>, _ function: @escaping () throws -> T?
+  )
     -> FunctionGeneratorPipelineIterator<T>
   {
     return FunctionGeneratorPipelineIterator<T>(f: function)

--- a/Sources/PenguinStructures/Type.swift
+++ b/Sources/PenguinStructures/Type.swift
@@ -1,0 +1,53 @@
+//******************************************************************************
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// A type whose full identity is known to the type system.
+///
+/// Generic function/method APIs often accept a `T.Type` parameter, where `T` is
+/// a generic parameter, to drive deduction, for example:
+///
+///     extension UnsafeRawPointer {
+///       func assumingMemoryBound<T>(to _: T.Type) -> UnsafePointer<T> { ... }
+///     }
+///
+/// which is then used as follows:
+///
+///     someRawPointer.assumingMemoryBound(to: Foo.self)
+///
+/// The problem with such interfaces is that you can easily end up driving type
+/// deduction with a value that doesn't match the deduced type:
+///
+///     let foo: Any.Type = Foo.self
+///     assert(foo == Foo.self)
+///     someRawPointer.assumingMemoryBound(to: foo) // not what you might expect
+///
+/// Despite the fact that the function argument is equal to `Foo.self`, the
+/// deduced type of `T` is `Any`.  It isn't always obvious at the use site of
+/// such an API that the *value* of the function argument is irrelevant and only
+/// its type matters. To avoid this problem, we can instead use `Type<T>` in the
+/// function signature:
+///
+///     extension UnsafeRawPointer {
+///       func assumingMemoryBound<T>(to _: Type<T>) -> UnsafePointer<T> { ... }
+///     }
+///
+/// which is then used as follows:
+///
+///     someRawPointer.assumingMemoryBound(to: Type<Foo>())
+///
+public struct Type<T> {
+  public init() {}
+}

--- a/Tests/PenguinGraphTests/AdjacencyListTests.swift
+++ b/Tests/PenguinGraphTests/AdjacencyListTests.swift
@@ -189,7 +189,7 @@ final class AdjacencyListTests: XCTestCase {
     XCTAssertEqual("Bob", g[vertex: vertices[2]].name)
 
     do {
-      var tmpMailboxes = SequentialMailboxes(for: g, sending: Empty.self)
+      var tmpMailboxes = SequentialMailboxes(for: g, sending: Type<Empty>())
       _ = try g.parallelStep(mailboxes: &tmpMailboxes, globalState: Empty()) {
         (ctx, v) in
         if v.name == "" { throw TestError() }

--- a/Tests/PenguinGraphTests/ParallelExpanderTests.swift
+++ b/Tests/PenguinGraphTests/ParallelExpanderTests.swift
@@ -36,10 +36,10 @@ final class ParallelExpanderTests: XCTestCase {
 
     let propertyMap = EdgeWeights([e1: 0.5, e2: 0.5, e3: 0.1, e4: 0.1])
 
-    var mb1 = PerThreadMailboxes(for: g, sending: IncomingEdgeWeightSumMessage.self)
+    var mb1 = PerThreadMailboxes(for: g, sending: Type<IncomingEdgeWeightSumMessage>())
     g.computeIncomingEdgeWeightSum(using: &mb1, propertyMap)
 
-    var mb2 = PerThreadMailboxes(for: g, sending: LabelBundle.self)
+    var mb2 = PerThreadMailboxes(for: g, sending: Type<LabelBundle>())
     g.propagateLabels(m1: 1.0, m2: 0.01, m3: 0.01, using: &mb2, propertyMap, maxStepCount: 10)
 
     assertClose(0, g[vertex: v2].computedLabels[0]!)
@@ -58,10 +58,10 @@ final class ParallelExpanderTests: XCTestCase {
 
     let propertyMap = EdgeWeights([e1: 0.5, e2: 0.5])
 
-    var mb1 = PerThreadMailboxes(for: g, sending: IncomingEdgeWeightSumMessage.self)
+    var mb1 = PerThreadMailboxes(for: g, sending: Type<IncomingEdgeWeightSumMessage>())
     g.computeIncomingEdgeWeightSum(using: &mb1, propertyMap)
 
-    var mb2 = PerThreadMailboxes(for: g, sending: LabelBundle.self)
+    var mb2 = PerThreadMailboxes(for: g, sending: Type<LabelBundle>())
     g.propagateLabels(m1: 1.0, m2: 0.01, m3: 0.01, using: &mb2, propertyMap, maxStepCount: 10)
 
     assertClose(0, g[vertex: v2].computedLabels[0]!)

--- a/Tests/PenguinGraphTests/VertexParallelTests.swift
+++ b/Tests/PenguinGraphTests/VertexParallelTests.swift
@@ -62,13 +62,13 @@ final class VertexParallelTests: XCTestCase {
 
   func testSequentialMessagePropagation() {
     var g = makeSimpleReachabilityGraph()
-    var mailboxes = SequentialMailboxes(for: g, sending: SimpleMessage.self)
+    var mailboxes = SequentialMailboxes(for: g, sending: Type<SimpleMessage>())
     runReachabilityTest(&g, &mailboxes)
   }
 
   func testTransitiveClosureSequentialMerging() {
     var g = makeSimpleReachabilityGraph()
-    var mailboxes = SequentialMailboxes(for: g, sending: Empty.self)
+    var mailboxes = SequentialMailboxes(for: g, sending: Type<Empty>())
     XCTAssertEqual(3, g.parallelTransitiveClosure(using: &mailboxes))
     let vIds = g.vertices
     XCTAssert(g[vertex: vIds[0]].isReachable)
@@ -82,7 +82,7 @@ final class VertexParallelTests: XCTestCase {
     var g = makeDistanceGraph()
     var mailboxes = SequentialMailboxes(
       for: g,
-      sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
+      sending: Type<DistanceSearchMessage<DistanceGraph.VertexId, Int>>())
     let vIds = g.vertices
 
     XCTAssertEqual(4, g.computeBFS(startingAt: vIds[0], using: &mailboxes))
@@ -112,7 +112,7 @@ final class VertexParallelTests: XCTestCase {
     var g = makeDistanceGraph()
     var mailboxes = SequentialMailboxes(
       for: g,
-      sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
+      sending: Type<DistanceSearchMessage<DistanceGraph.VertexId, Int>>())
     let vIds = g.vertices
 
     let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
@@ -151,7 +151,7 @@ final class VertexParallelTests: XCTestCase {
 
     var mailboxes = SequentialMailboxes(
       for: g,
-      sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
+      sending: Type<DistanceSearchMessage<DistanceGraph.VertexId, Int>>())
     let vIds = g.vertices
 
     let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
@@ -190,7 +190,7 @@ final class VertexParallelTests: XCTestCase {
 
     var mailboxes = SequentialMailboxes(
       for: g,
-      sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
+      sending: Type<DistanceSearchMessage<DistanceGraph.VertexId, Int>>())
     let vIds = g.vertices
 
     let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
@@ -240,7 +240,7 @@ final class VertexParallelTests: XCTestCase {
     let g = makeDistanceGraph()
     let vIds = g.vertices
     ComputeThreadPools.withPool(testPool) {
-      let mailboxes = PerThreadMailboxes(for: g, sending: TestMessage.self)
+      let mailboxes = PerThreadMailboxes(for: g, sending: Type<TestMessage>())
 
       XCTAssertFalse(mailboxes.deliver())
       XCTAssertFalse(mailboxes.deliver())
@@ -285,7 +285,7 @@ final class VertexParallelTests: XCTestCase {
       let vIds = g.vertices
       var mailboxes = PerThreadMailboxes(
         for: g,
-        sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
+        sending: Type<DistanceSearchMessage<DistanceGraph.VertexId, Int>>())
 
       let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)
       XCTAssertEqual(
@@ -470,7 +470,7 @@ extension VertexParallelTests {
       var g = makeDistanceGraph()
       var mailboxes = PerThreadMailboxes(
         for: g,
-        sending: DistanceSearchMessage<DistanceGraph.VertexId, Int>.self)
+        sending: Type<DistanceSearchMessage<DistanceGraph.VertexId, Int>>())
 
       let vIds = g.vertices
       let edgeDistanceMap = InternalEdgePropertyMap(for: g).transform(\.distance)

--- a/Tests/PenguinParallelTests/PosixConcurrencyPlatformTests.swift
+++ b/Tests/PenguinParallelTests/PosixConcurrencyPlatformTests.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import PenguinParallelWithFoundation
+import struct PenguinStructures.Type
 import XCTest
 
 final class PosixConcurrencyPlatformTests: XCTestCase {
@@ -89,7 +90,7 @@ final class PosixConcurrencyPlatformTests: XCTestCase {
   func testThreadLocalVariables() {
     typealias TLS = PosixConcurrencyPlatform.ThreadLocalStorage
     XCTAssertEqual(0, LeakChecker.allocationCount)
-    let key = TLS.makeKey(for: LeakChecker.self)
+    let key = TLS.makeKey(for: Type<LeakChecker>())
 
     do {
       let checker = LeakChecker()
@@ -127,7 +128,7 @@ final class PosixConcurrencyPlatformTests: XCTestCase {
     typealias TLS = PosixConcurrencyPlatform.ThreadLocalStorage
     XCTAssertEqual(0, LeakChecker.allocationCount)  // Ensure we're starting from clean.
 
-    let key = TLS.makeKey(for: LeakChecker.self)
+    let key = TLS.makeKey(for: Type<LeakChecker>())
     XCTAssertNil(key.localValue)
     key.localValue = LeakChecker()
     XCTAssertEqual(1, LeakChecker.allocationCount)

--- a/Tests/PenguinPipelineTests/FunctionGeneratorPipelineIteratorTests.swift
+++ b/Tests/PenguinPipelineTests/FunctionGeneratorPipelineIteratorTests.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import PenguinPipeline
+import struct PenguinStructures.Type
 import XCTest
 
 final class FunctionGeneratorPipelineIteratorTests: XCTestCase {
@@ -32,7 +33,7 @@ final class FunctionGeneratorPipelineIteratorTests: XCTestCase {
 
   func testSimpleInfiniteFunctionGenerator() {
     var i = 0
-    var itr = PipelineIterator.fromFunction(Int.self) {
+    var itr = PipelineIterator.fromFunction(Type<Int>()) {
       i += 1
       return i
     }.take(3)

--- a/Tests/PenguinPipelineTests/PrefetchPipelineIteratorTests.swift
+++ b/Tests/PenguinPipelineTests/PrefetchPipelineIteratorTests.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import PenguinPipeline
+import struct PenguinStructures.Type
 import XCTest
 
 final class PrefetchPipelineIteratorTests: XCTestCase {
@@ -29,7 +30,7 @@ final class PrefetchPipelineIteratorTests: XCTestCase {
       }
 
       var i = 0
-      let tmp = PipelineIterator.fromFunction(Int.self) {
+      let tmp = PipelineIterator.fromFunction(Type<Int>()) {
         let oldI = i
         defer {
           // Use a defer block to signal at the last possible moment


### PR DESCRIPTION
Very mechanical change whose motivation is explained in the doc comment for Type.swift, in the commit