### PR TITLE
Make doc comments reflect semantics, not language construct.

### DIFF
--- a/Sources/PenguinStructures/FixedSizeArray.swift
+++ b/Sources/PenguinStructures/FixedSizeArray.swift
@@ -45,7 +45,7 @@ public protocol FixedSizeArray : MutableCollection, RandomAccessCollection,
   /// with `newElement` inserted at `targetPosition`.
   func inserting(_ newElement: Element, at targetPosition: Index) -> ArrayN<Self>
 
-  /// The static count of elements in `Self`.
+  /// The number of elements in an instance.
   static var count: Int { get }
 }
 
@@ -116,7 +116,7 @@ public struct Array0<T> : FixedSizeArray {
     return .init(head: newElement, tail: self)
   }
 
-  /// The static count of elements in `Self`.
+  /// The number of elements in an instance.
   public static var count: Int { 0 }
 
   // ======== Collection Requirements ============
@@ -203,7 +203,7 @@ public struct ArrayN<Tail: FixedSizeArray> : FixedSizeArray {
     precondition(i >= 0 && i < count, "index out of range")
   }
 
-  /// The static count of elements in `Self`.
+  /// The number of elements in an instance.
   public static var count: Int { Tail.count &+ 1 }
   
   // ======== Collection Requirements ============


### PR DESCRIPTION
`Self` doesn't contain elements; it's a type, and “static” could mean lots of
things in this context.  The fact that it is the same as part of the
declaration, which is apparent to anyone reading the comment just like type
information would be, makes it potentially confusing.