### PR TITLE
Add canonical zero-capacity ArrayStorage instance.

### DIFF
--- a/Sources/Benchmarks/ArrayStorage.swift
+++ b/Sources/Benchmarks/ArrayStorage.swift
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 import Benchmark
+import PenguinStructures
 
-Benchmark.main([
-  arrayStorage,
-  nonBlockingCondition,
-  nonBlockingThreadPool,
-  adjacencyList,
-  parallelExpander,
-])
+let arrayStorage = BenchmarkSuite(name: "ArrayStorage") { suite in
+  
+  suite.benchmark("Create empty.") {
+    _ = ArrayStorage<Int>(EmptyCollection())
+  }
+}

--- a/Sources/PenguinStructures/AnyArrayBuffer.swift
+++ b/Sources/PenguinStructures/AnyArrayBuffer.swift
@@ -69,11 +69,13 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
     self.dispatch = src.dispatch
   }
 
-  /// The type of element stored here.
-  public var elementType: Any.Type { storage?.elementType ?? Never.self }
+  /// Returns `true` iff an element of type `e` can be appended to `self`.
+  public func canAppendElement(ofType e: TypeID) -> Bool {
+    storage.unsafelyUnwrapped.isUsable(forElementType: e)
+  }
 
   /// Returns the result of invoking `body` on a typed alias of `self`, if
-  /// `self.elementType == Element.self`; returns `nil` otherwise.
+  /// `self.canStoreElement(ofType: Type<Element>.id)`; returns `nil` otherwise.
   public mutating func mutate<Element, R>(
     ifElementType _: Type<Element>,
     _ body: (_ me: inout ArrayBuffer<Element>)->R

--- a/Sources/PenguinStructures/AnyArrayBuffer.swift
+++ b/Sources/PenguinStructures/AnyArrayBuffer.swift
@@ -54,7 +54,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
   public typealias Storage = AnyArrayStorage
   
   /// A bounded contiguous buffer comprising all of `self`'s storage.
-  public var storage: Storage
+  public var storage: Storage?
   /// A “vtable” of functions implementing type-erased operations that depend on the Element type.
   public let dispatch: Dispatch
   
@@ -71,7 +71,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
 
   /// Returns `true` iff an element of type `e` can be appended to `self`.
   public func canAppendElement(ofType e: TypeID) -> Bool {
-    storage.isUsable(forElementType: e)
+    storage.unsafelyUnwrapped.isUsable(forElementType: e)
   }
 
   /// Returns the result of invoking `body` on a typed alias of `self`, if
@@ -82,7 +82,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
   ) -> R? {
     // TODO: check for spurious ARC traffic
     guard var me = ArrayBuffer<Element>(self) else { return nil }
-    self.storage = .zeroCapacityInstance
+    self.storage = nil
     defer { self.storage = me.storage.object }
     return body(&me)
   }
@@ -96,7 +96,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
   ) -> R {
     // TODO: check for spurious ARC traffic
     var me = ArrayBuffer<Element>(unsafelyDowncasting: self)
-    self.storage = .zeroCapacityInstance
+    self.storage = nil
     defer { self.storage = me.storage.object }
     return body(&me)
   }
@@ -104,9 +104,9 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
 
 extension AnyArrayBuffer {
   /// The number of stored elements.
-  public var count: Int { storage.count }
+  public var count: Int { storage.unsafelyUnwrapped.count }
 
   /// The number of elements that can be stored in `self` without reallocation,
   /// provided its representation is not shared with other instances.
-  public var capacity: Int { storage.capacity }
+  public var capacity: Int { storage.unsafelyUnwrapped.capacity }
 }

--- a/Sources/PenguinStructures/AnyArrayBuffer.swift
+++ b/Sources/PenguinStructures/AnyArrayBuffer.swift
@@ -54,7 +54,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
   public typealias Storage = AnyArrayStorage
   
   /// A bounded contiguous buffer comprising all of `self`'s storage.
-  public var storage: Storage?
+  public var storage: Storage
   /// A “vtable” of functions implementing type-erased operations that depend on the Element type.
   public let dispatch: Dispatch
   
@@ -71,7 +71,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
 
   /// Returns `true` iff an element of type `e` can be appended to `self`.
   public func canAppendElement(ofType e: TypeID) -> Bool {
-    storage.unsafelyUnwrapped.isUsable(forElementType: e)
+    storage.isUsable(forElementType: e)
   }
 
   /// Returns the result of invoking `body` on a typed alias of `self`, if
@@ -82,7 +82,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
   ) -> R? {
     // TODO: check for spurious ARC traffic
     guard var me = ArrayBuffer<Element>(self) else { return nil }
-    self.storage = nil
+    self.storage = .zeroCapacityInstance
     defer { self.storage = me.storage.object }
     return body(&me)
   }
@@ -96,7 +96,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
   ) -> R {
     // TODO: check for spurious ARC traffic
     var me = ArrayBuffer<Element>(unsafelyDowncasting: self)
-    self.storage = nil
+    self.storage = .zeroCapacityInstance
     defer { self.storage = me.storage.object }
     return body(&me)
   }
@@ -104,9 +104,9 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
 
 extension AnyArrayBuffer {
   /// The number of stored elements.
-  public var count: Int { storage.unsafelyUnwrapped.count }
+  public var count: Int { storage.count }
 
   /// The number of elements that can be stored in `self` without reallocation,
   /// provided its representation is not shared with other instances.
-  public var capacity: Int { storage.unsafelyUnwrapped.capacity }
+  public var capacity: Int { storage.capacity }
 }

--- a/Sources/PenguinStructures/AnyArrayBuffer.swift
+++ b/Sources/PenguinStructures/AnyArrayBuffer.swift
@@ -100,12 +100,6 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
     defer { self.storage = me.storage.object }
     return body(&me)
   }
-
-  /// Ensure that we hold uniquely-referenced storage.
-  public mutating func ensureUniqueStorage() {
-    guard !isKnownUniquelyReferenced(&storage) else { return }
-    storage = storage.unsafelyUnwrapped.makeCopy()
-  }
 }
 
 extension AnyArrayBuffer {

--- a/Sources/PenguinStructures/AnyArrayBuffer.swift
+++ b/Sources/PenguinStructures/AnyArrayBuffer.swift
@@ -15,7 +15,7 @@
 extension AnyArrayBuffer where Dispatch == AnyObject {
   /// Creates an instance containing the same elements as `src`.
   public init<Element>(_ src: ArrayBuffer<Element>) {
-    self.storage = src.storage
+    self.storage = src.storage.object
     self.dispatch = Void.self as AnyObject
   }
 
@@ -58,8 +58,8 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
   /// A “vtable” of functions implementing type-erased operations that depend on the Element type.
   public let dispatch: Dispatch
   
-  public init(storage: Storage, dispatch: Dispatch) {
-    self.storage = storage
+  public init<Element>(storage: ArrayStorage<Element>, dispatch: Dispatch) {
+    self.storage = storage.object
     self.dispatch = dispatch
   }
   
@@ -83,7 +83,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
     // TODO: check for spurious ARC traffic
     guard var me = ArrayBuffer<Element>(self) else { return nil }
     self.storage = nil
-    defer { self.storage = me.storage }
+    defer { self.storage = me.storage.object }
     return body(&me)
   }
 
@@ -97,7 +97,7 @@ public struct AnyArrayBuffer<Dispatch: AnyObject> {
     // TODO: check for spurious ARC traffic
     var me = ArrayBuffer<Element>(unsafelyDowncasting: self)
     self.storage = nil
-    defer { self.storage = me.storage }
+    defer { self.storage = me.storage.object }
     return body(&me)
   }
 

--- a/Sources/PenguinStructures/ArrayBuffer.swift
+++ b/Sources/PenguinStructures/ArrayBuffer.swift
@@ -72,15 +72,15 @@ extension ArrayBuffer {
   ///
   /// - Fails unless `Element.self == src.elementType`.
   public init?<Dispatch>(_ src: AnyArrayBuffer<Dispatch>) {
-    guard src.storage.isUsable(forElementType: Type<Element>.id) else { return nil }
-    self.storage = .init(unsafelyAdopting: src.storage)
+    guard src.storage?.isUsable(forElementType: Type<Element>.id) == true else { return nil }
+    self.storage = .init(unsafelyAdopting: src.storage.unsafelyUnwrapped)
   }
   
   /// Creates an instance referring to the same elements as `src`.
   ///
   /// - Requires: `Element.self == src.elementType`.
   public init<Dispatch>(unsafelyDowncasting src: AnyArrayBuffer<Dispatch>) {
-    storage = .init(unsafelyAdopting: src.storage)
+    storage = .init(unsafelyAdopting: src.storage.unsafelyUnwrapped)
   }
   
   /// Appends `x`, returning the index of the appended element.

--- a/Sources/PenguinStructures/ArrayBuffer.swift
+++ b/Sources/PenguinStructures/ArrayBuffer.swift
@@ -72,15 +72,15 @@ extension ArrayBuffer {
   ///
   /// - Fails unless `Element.self == src.elementType`.
   public init?<Dispatch>(_ src: AnyArrayBuffer<Dispatch>) {
-    guard src.storage?.isUsable(forElementType: Type<Element>.id) == true else { return nil }
-    self.storage = .init(unsafelyAdopting: src.storage.unsafelyUnwrapped)
+    guard src.storage.isUsable(forElementType: Type<Element>.id) else { return nil }
+    self.storage = .init(unsafelyAdopting: src.storage)
   }
   
   /// Creates an instance referring to the same elements as `src`.
   ///
   /// - Requires: `Element.self == src.elementType`.
   public init<Dispatch>(unsafelyDowncasting src: AnyArrayBuffer<Dispatch>) {
-    storage = .init(unsafelyAdopting: src.storage.unsafelyUnwrapped)
+    storage = .init(unsafelyAdopting: src.storage)
   }
   
   /// Appends `x`, returning the index of the appended element.

--- a/Sources/PenguinStructures/ArrayBuffer.swift
+++ b/Sources/PenguinStructures/ArrayBuffer.swift
@@ -84,8 +84,8 @@ extension ArrayBuffer {
   ///
   /// - Requires: `Element.self == src.elementType`.
   public init<Dispatch>(unsafelyDowncasting src: AnyArrayBuffer<Dispatch>) {
-    self.storage = unsafeDowncast(
-      src.storage.unsafelyUnwrapped, to: Storage.self)
+    self.storage
+      = src.storage.unsafelyUnwrapped.unsafelyDowncastingElements(to: Type<Element>())
   }
   
   /// Appends `x`, returning the index of the appended element.

--- a/Sources/PenguinStructures/ArrayBuffer.swift
+++ b/Sources/PenguinStructures/ArrayBuffer.swift
@@ -63,36 +63,31 @@ extension ArrayBuffer {
       count: count, minimumCapacity: minimumCapacity, initializeElements: initializeElements)
   }
 
-  /// Creates an instance using `s` as a backing buffer, replacing its value with `nil`.
-  ///
-  /// - Requires: `isKnownUniquelyReferenced(&s)`.
-  public init(unsafeUniqueStorage s: inout Storage?) {
-    assert(isKnownUniquelyReferenced(&s))
-    self.storage = s.unsafelyUnwrapped
-    s = nil
+  /// Creates an instance using the memory of `s` for its storage.
+  public init(_ s: Storage) {
+    self.storage = s
   }
 
   /// Creates an instance referring to the same elements as `src`.
   ///
   /// - Fails unless `Element.self == src.elementType`.
   public init?<Dispatch>(_ src: AnyArrayBuffer<Dispatch>) {
-    guard let s = src.storage as? Storage else { return nil }
-    self.storage = s
+    guard src.storage?.isUsable(forElementType: Type<Element>.id) == true else { return nil }
+    self.storage = .init(unsafelyAdopting: src.storage.unsafelyUnwrapped)
   }
   
   /// Creates an instance referring to the same elements as `src`.
   ///
   /// - Requires: `Element.self == src.elementType`.
   public init<Dispatch>(unsafelyDowncasting src: AnyArrayBuffer<Dispatch>) {
-    self.storage
-      = src.storage.unsafelyUnwrapped.unsafelyDowncastingElements(to: Type<Element>())
+    storage = .init(unsafelyAdopting: src.storage.unsafelyUnwrapped)
   }
   
   /// Appends `x`, returning the index of the appended element.
   ///
   /// - Complexity: Amortized O(1).
   public mutating func append(_ x: Element) -> Int {
-    let isUnique = isKnownUniquelyReferenced(&storage)
+    let isUnique = storage.memoryIsUniquelyReferenced()
     if isUnique, let r = storage.append(x) { return r }
     storage = storage.appending(x, moveElements: isUnique)
     return count - 1
@@ -113,10 +108,11 @@ extension ArrayBuffer {
     return storage.withUnsafeMutableBufferPointer(body)
   }
 
-  /// Ensure that we hold uniquely-referenced storage.
+  /// Ensure that `self` holds uniquely-referenced storage, copying its memory if necessary.
   public mutating func ensureUniqueStorage() {
-    guard !isKnownUniquelyReferenced(&storage) else { return }
-    storage = storage.makeCopy()
+    if !storage.memoryIsUniquelyReferenced() {
+      storage = storage.makeCopy()
+    }
   }
 }
 
@@ -138,7 +134,7 @@ extension ArrayBuffer: RandomAccessCollection, MutableCollection {
   public subscript(_ i: Index) -> Element {
     get { storage[i] }
     _modify {
-      if isKnownUniquelyReferenced(&storage) { yield &storage[i] } 
+      if storage.memoryIsUniquelyReferenced() { yield &storage[i] } 
       else {
         storage = storage.makeCopy()
         yield &storage[i]

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -43,7 +43,7 @@ public class AnyArrayStorage {
   ///
   /// Because you can't write onto this instance and it stores no elements, we can use it as backing
   /// memory for an `ArrayBuffer<T>` regardless of `T`.
-  internal static var zeroCapacityInstance: AnyArrayStorage = unsafeDowncast(
+  internal static let zeroCapacityInstance: AnyArrayStorage = unsafeDowncast(
     // Use Never as the dynamic element type, to make this instance recognizable in the debugger.
     Handle<Never>(bufferClass: ArrayStorage<Never>.Class.self, minimumCapacity: 0) { _, _ in
       // Ignore the size actually allocated and make sure the capacity is zero.

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -278,7 +278,6 @@ extension ArrayStorage {
 }
 
 extension ArrayStorage : RandomAccessCollection, MutableCollection {
-  
   /// The position of the first element.
   public var startIndex: Index { 0 }
   
@@ -296,6 +295,7 @@ extension ArrayStorage : RandomAccessCollection, MutableCollection {
       yield access.withUnsafeMutablePointers { _, base in base[i] }
     }
     _modify {
+      assert(i >= 0 && i < count, "index out of range")
       defer { _fixLifetime(self) }
       let base = access.withUnsafeMutablePointers { _, base in base }
       yield &base[i]

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -32,7 +32,7 @@ fileprivate struct ArrayHeader {
 public class AnyArrayStorage: FactoryInitializable {    
   /// Returns a distinct, uniquely-referenced, copy of `self`—unless its capacity is 0, in which
   /// case it returns `self`.
-  public func makeCopy() -> Self { fatalError("implement me as clone()") }
+  public func makeCopy() -> Self { fatalError("implement me") }
   
   /// The type of element stored here.
   fileprivate class var elementType: TypeID {

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -26,10 +26,7 @@ fileprivate struct ArrayHeader {
   var capacity: Int
 }
 
-  /// A way to access the storage when the element type is known
-fileprivate typealias Handle<Element> = ManagedBufferPointer<ArrayHeader, Element>
-
-/// Contiguous storage of homogeneous elements of statically unknown type.
+/// Base class for contiguous storage of homogeneous elements of statically unknown type.
 ///
 /// This class provides the element-type-agnostic API for ArrayStorage<T>.
 public class AnyArrayStorage: FactoryInitializable {    
@@ -55,6 +52,9 @@ public class AnyArrayStorage: FactoryInitializable {
 }
 
 extension AnyArrayStorage {
+  /// A way to access the storage when the element type is known
+  fileprivate typealias Handle<Element> = ManagedBufferPointer<ArrayHeader, Element>
+
   /// The number of elements stored in `self`.
   ///
   /// - Invariant: `count <= capacity`
@@ -154,12 +154,10 @@ fileprivate final class ArrayStorage_<Element>: AnyArrayStorage {
 }
 
 extension ArrayStorage { 
-  /// A type whose instances can be used to access the memory of `self` with a
-  /// degree of type-safety.
-  fileprivate typealias Accessor = Handle<Element>
-
   /// A handle to the memory of `self` providing a degree of type-safety.
-  fileprivate var access: Accessor { .init(unsafeBufferObject: object) }
+  fileprivate var access: ManagedBufferPointer<ArrayHeader, Element> {
+    .init(unsafeBufferObject: object)
+  }
   
   /// Creates an instance with the same elements as `contents`, having a
   /// `capacity` of at least `minimumCapacity`.
@@ -201,7 +199,7 @@ extension ArrayStorage {
       return
     }
     
-    let access = Handle<Element>(
+    let access = ManagedBufferPointer<ArrayHeader, Element>(
       bufferClass: ArrayStorage_<Element>.self,
       minimumCapacity: capacityRequest
     ) { buffer, getCapacity in 

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -29,7 +29,7 @@ fileprivate struct ArrayHeader {
 /// Base class for contiguous storage of homogeneous elements of statically unknown type.
 ///
 /// This class provides the element-type-agnostic API for ArrayStorage<T>.
-public class AnyArrayStorage: FactoryInitializable {    
+public class AnyArrayStorage {    
   /// Returns a distinct, uniquely-referenced, copy of `self`—unless its capacity is 0, in which
   /// case it returns `self`.
   public func makeCopy() -> Self { fatalError("implement me") }

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -156,9 +156,7 @@ extension ArrayStorage {
   
   /// Creates an instance with the same elements as `contents`, having a
   /// `capacity` of at least `minimumCapacity`.
-  public init<Contents: Collection>(
-    _ contents: Contents, minimumCapacity: Int = 0
-  )
+  public init<Contents: Collection>(_ contents: Contents, minimumCapacity: Int = 0)
     where Contents.Element == Element
   {
     let count = contents.count

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -79,7 +79,10 @@ extension AnyArrayStorage {
     }
   }
 
-  /// The universal empty instance
+  /// The universal zero-capacity instance.
+  ///
+  /// Because you can't write onto this instance and it stores no elements, we can use it as backing
+  /// memory for an `ArrayBuffer<T>` regardless of `T`.
   internal static var zeroCapacityInstance: AnyArrayStorage = unsafeDowncast(
     Handle<Never>(bufferClass: ArrayStorage_<Never>.self, minimumCapacity: 0) { _, _ in
       ArrayHeader(count: 0, capacity: 0)

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -30,10 +30,6 @@ fileprivate struct ArrayHeader {
 ///
 /// This class provides the element-type-agnostic API for ArrayStorage<T>.
 public class AnyArrayStorage {    
-  /// Returns a distinct, uniquely-referenced, copy of `self`—unless its capacity is 0, in which
-  /// case it returns `self`.
-  public func makeCopy() -> Self { fatalError("implement me") }
-  
   /// The type of element stored here.
   fileprivate class var elementType: TypeID {
     fatalError("implement me as .init(Element.self)")
@@ -111,7 +107,9 @@ public struct ArrayStorage<Element> {
   /// Returns a distinct, uniquely-referenced, copy of `self`—unless its capacity is 0, in which
   /// case it returns `self`.
   public func makeCopy() -> Self {
-    .init(unsafelyAdopting: object.makeCopy())
+    replacementStorage(count: count, minimumCapacity: capacity) { source, uninitializedBase in
+      uninitializedBase.initialize(from: source, count: count)
+    }
   }
   
   /// The number of elements stored in `self`.
@@ -142,18 +140,6 @@ fileprivate final class ArrayStorage_<Element>: AnyArrayStorage {
 
   /// The type of element stored here.
   fileprivate final override class var elementType: TypeID { .init(Element.self) }
-
-  /// Returns a distinct, uniquely-referenced, copy of `self`—unless its capacity is 0, in which
-  /// case it returns `self`.
-  public final override func makeCopy() -> Self {
-    if capacity == 0 { return self }
-    let count = self.count
-    let r = ArrayStorage<Element>(unsafelyAdopting: self)
-      .replacementStorage(count: count, minimumCapacity: capacity) { source, uninitializedBase in
-        uninitializedBase.initialize(from: source, count: count)
-      }
-    return unsafeDowncast(r.object, to: Self.self)
-  }
 }
 
 extension ArrayStorage { 

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -150,7 +150,7 @@ extension ArrayStorage {
 
 extension ArrayStorage { 
   /// A handle to the memory of `self` providing a degree of type-safety.
-  fileprivate var access: ManagedBufferPointer<ArrayHeader, Element> {
+  private var access: ManagedBufferPointer<ArrayHeader, Element> {
     .init(unsafeBufferObject: object)
   }
   

--- a/Sources/PenguinStructures/ArrayStorage.swift
+++ b/Sources/PenguinStructures/ArrayStorage.swift
@@ -60,12 +60,12 @@ extension AnyArrayStorage {
   /// - Invariant: `count <= capacity`
   public fileprivate(set) final var count: Int {
     get {
-      Handle<Never>(unsafeBufferObject: self).withUnsafeMutablePointerToHeader {
+      Handle<()>(unsafeBufferObject: self).withUnsafeMutablePointerToHeader {
         h in h.pointee.count
       }
     }
     set {
-      Handle<Never>(unsafeBufferObject: self).withUnsafeMutablePointerToHeader {
+      Handle<()>(unsafeBufferObject: self).withUnsafeMutablePointerToHeader {
         assert(newValue <= $0.pointee.capacity)
         $0.pointee.count = newValue
       }
@@ -74,7 +74,7 @@ extension AnyArrayStorage {
 
   /// The maximum number of elements that can be stored in `self`.
   public final var capacity: Int {
-    Handle<Never>(unsafeBufferObject: self).withUnsafeMutablePointerToHeader {
+    Handle<()>(unsafeBufferObject: self).withUnsafeMutablePointerToHeader {
       $0.pointee.capacity
     }
   }

--- a/Sources/PenguinStructures/FactoryInitializable.swift
+++ b/Sources/PenguinStructures/FactoryInitializable.swift
@@ -62,4 +62,13 @@ extension FactoryInitializable where Self: AnyObject {
   public init(aliasing me: FactoryBase) {
     self = me as! Self
   }
+
+  /// “Creates” an instance that is just another reference to `me`, regardless of the dynamic type
+  /// of “me”.
+  ///
+  /// - Warning: do not use this initializer unless you're really, absolutely, sure you know what
+  ///   you're doing; it breaks type safety.
+  public init(unsafelyBitCasting me: FactoryBase) {
+    self = unsafeBitCast(me as AnyObject, to: Self.self)
+  }
 }

--- a/Sources/PenguinStructures/Type.swift
+++ b/Sources/PenguinStructures/Type.swift
@@ -50,4 +50,7 @@
 ///
 public struct Type<T> {
   public init() {}
+
+  /// The `TypeID` value corresponding to `T`.
+  public static var id: TypeID { .init(T.self) }
 }

--- a/Tests/PenguinStructuresTests/ArrayBufferTests.swift
+++ b/Tests/PenguinStructuresTests/ArrayBufferTests.swift
@@ -160,11 +160,10 @@ class ArrayBufferTests: XCTestCase {
     b.checkMutableCollectionSemantics(source: 50..<150)
   }
 
-  func test_unsafeUniqueStorageInit() {
+  func test_storageInit() {
     let source = 0...66
-    var s = Optional(ArrayStorage<Int>(source))
-    let a = ArrayBuffer(unsafeUniqueStorage: &s)
-    XCTAssert(s == nil)
+    let s = ArrayStorage<Int>(source)
+    let a = ArrayBuffer(s)
     XCTAssert(a.elementsEqual(source))
   }
   
@@ -202,7 +201,7 @@ class ArrayBufferTests: XCTestCase {
     ("test_withUnsafeMutableBufferPointer", test_withUnsafeMutableBufferPointer),
     ("test_append", test_append),
     ("test_collectionSemantics", test_collectionSemantics),
-    ("test_unsafeUniqueStorageInit", test_unsafeUniqueStorageInit),
+    ("test_storageInit", test_storageInit),
     ("test_unsafeInitializingInit", test_unsafeInitializingInit),
   ]
 }

--- a/Tests/PenguinStructuresTests/ArrayStorageExtensionTests.swift
+++ b/Tests/PenguinStructuresTests/ArrayStorageExtensionTests.swift
@@ -204,10 +204,6 @@ class ArrayStorageExtensionTests: XCTestCase {
       sortedSource: factoids(99..<199))
   }
 
-  func test_elementType() {
-    XCTAssert(ArrayStorage<Truthy>.elementType == Truthy.self)
-  }
-  
   func test_replacementStorage() {
     ArrayStorage<Truthy>.test_replacementStorage(source: factoids(0..<10))
   }
@@ -300,7 +296,6 @@ class ArrayStorageExtensionTests: XCTestCase {
     ("test_create", test_emptyInit),
     ("test_append", test_append),
     ("test_withUnsafeMutableBufferPointer", test_withUnsafeMutableBufferPointer),
-    ("test_elementType", test_elementType),
     ("test_replacementStorage", test_replacementStorage),
     ("test_makeCopy", test_makeCopy),
     ("test_deinit", test_deinit),

--- a/Tests/PenguinStructuresTests/ArrayStorageTests+Internal.swift
+++ b/Tests/PenguinStructuresTests/ArrayStorageTests+Internal.swift
@@ -1,0 +1,54 @@
+//******************************************************************************
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+import XCTest
+@testable import PenguinStructures
+
+// Reusable test implementations
+
+class ArrayStorageTests_Internal: XCTestCase {
+  func test_isUsable() {
+    let noCapacity = ArrayStorage<Double>()
+    XCTAssert(noCapacity.object.isUsable(forElementType: Type<Double>.id))
+    XCTAssert(
+      noCapacity.object.isUsable(forElementType: Type<Int>.id),
+      """
+      Storage with zero capacity should be the canonical empty storage, \
+      which is valid for any element type.
+      """)
+
+    let someCapacity = ArrayStorage<Double>(minimumCapacity: 3)
+    XCTAssert(someCapacity.object.isUsable(forElementType: Type<Double>.id))
+    XCTAssertFalse(
+      someCapacity.object.isUsable(forElementType: Type<Int>.id),
+      """
+      Storage with non-zero capacity should only be usable for the type \
+      of element for which it was created.
+      """)
+    
+    let nonEmpty = ArrayStorage(1...10)
+    XCTAssert(nonEmpty.object.isUsable(forElementType: Type<Int>.id))
+    XCTAssertFalse(
+      nonEmpty.object.isUsable(forElementType: Type<Double>.id),
+      """
+      Storage with non-zero capacity should only be usable for the type \
+      of element for which it was created.
+      """)
+  }
+  
+  static var allTests = [
+    ("test_isUsable", test_isUsable),
+  ]
+}

--- a/Tests/PenguinStructuresTests/ArrayStorageTests.swift
+++ b/Tests/PenguinStructuresTests/ArrayStorageTests.swift
@@ -232,11 +232,33 @@ class ArrayStorageTests: XCTestCase {
       sortedSource: 99..<199)
   }
   
-  func test_elementType() {
-    let intStorage = ArrayStorage<Int>(minimumCapacity: 0)
-    XCTAssert(type(of: intStorage).elementType == Int.self)
-    let uintStorage = ArrayStorage<UInt>(minimumCapacity: 0)
-    XCTAssert(type(of: uintStorage).elementType == UInt.self)
+  func test_isUsable() {
+    let noCapacity = ArrayStorage<Double>()
+    XCTAssert(noCapacity.isUsable(forElementType: Type<Double>.id))
+    XCTAssert(
+      noCapacity.isUsable(forElementType: Type<Int>.id),
+      """
+      Storage with zero capacity should be the canonical empty storage, \
+      which is valid for any element type.
+      """)
+
+    let someCapacity = ArrayStorage<Double>(minimumCapacity: 3)
+    XCTAssert(someCapacity.isUsable(forElementType: Type<Double>.id))
+    XCTAssertFalse(
+      someCapacity.isUsable(forElementType: Type<Int>.id),
+      """
+      Storage with non-zero capacity should only be usable for the type \
+      of element for which it was created.
+      """)
+    
+    let nonEmpty = ArrayStorage(1...10)
+    XCTAssert(nonEmpty.isUsable(forElementType: Type<Int>.id))
+    XCTAssertFalse(
+      nonEmpty.isUsable(forElementType: Type<Double>.id),
+      """
+      Storage with non-zero capacity should only be usable for the type \
+      of element for which it was created.
+      """)
   }
   
   func test_replacementStorage() {
@@ -270,8 +292,7 @@ class ArrayStorageTests: XCTestCase {
     ("test_append", test_append),
     ("test_appending", test_appending),
     ("test_withUnsafeMutableBufferPointer", test_withUnsafeMutableBufferPointer),
-    ("test_elementType", test_elementType),
-    ("test_elementType", test_elementType),
+    ("test_isUsable", test_isUsable),
     ("test_replacementStorage", test_replacementStorage),
     ("test_deinit", test_deinit),
     ("test_copyingInit", test_copyingInit),

--- a/Tests/PenguinStructuresTests/ArrayStorageTests.swift
+++ b/Tests/PenguinStructuresTests/ArrayStorageTests.swift
@@ -76,7 +76,7 @@ extension ArrayStorage where Element: Equatable {
     where Source.Element == Element
   {
     for n in 0..<(source.count + 2) {
-      let s = Self(minimumCapacity: n)
+      var s = Self(minimumCapacity: n)
       
       func doAppending(_ e: Element, moveElements: Bool) -> Self {
         let saveCapacity = s.capacity
@@ -130,8 +130,11 @@ extension ArrayStorage where Element: Equatable {
           (newBase + i).initialize(to: x)
         }
       }
-      XCTAssertEqual(
-        newBaseAddress, r.withUnsafeMutableBufferPointer { $0.baseAddress! })
+      
+      if m != 0 {
+        XCTAssertEqual(
+          newBaseAddress, r.withUnsafeMutableBufferPointer { $0.baseAddress! })
+      }
       XCTAssertEqual(r.count, m)
       XCTAssertGreaterThanOrEqual(r.capacity, m)
     }
@@ -238,35 +241,6 @@ class ArrayStorageTests: XCTestCase {
       sortedSource: 99..<199)
   }
   
-  func test_isUsable() {
-    let noCapacity = ArrayStorage<Double>()
-    XCTAssert(noCapacity.isUsable(forElementType: Type<Double>.id))
-    XCTAssert(
-      noCapacity.isUsable(forElementType: Type<Int>.id),
-      """
-      Storage with zero capacity should be the canonical empty storage, \
-      which is valid for any element type.
-      """)
-
-    let someCapacity = ArrayStorage<Double>(minimumCapacity: 3)
-    XCTAssert(someCapacity.isUsable(forElementType: Type<Double>.id))
-    XCTAssertFalse(
-      someCapacity.isUsable(forElementType: Type<Int>.id),
-      """
-      Storage with non-zero capacity should only be usable for the type \
-      of element for which it was created.
-      """)
-    
-    let nonEmpty = ArrayStorage(1...10)
-    XCTAssert(nonEmpty.isUsable(forElementType: Type<Int>.id))
-    XCTAssertFalse(
-      nonEmpty.isUsable(forElementType: Type<Double>.id),
-      """
-      Storage with non-zero capacity should only be usable for the type \
-      of element for which it was created.
-      """)
-  }
-  
   func test_replacementStorage() {
     ArrayStorage<Int>.test_replacementStorage(source: 0..<10)
   }
@@ -298,7 +272,6 @@ class ArrayStorageTests: XCTestCase {
     ("test_append", test_append),
     ("test_appending", test_appending),
     ("test_withUnsafeMutableBufferPointer", test_withUnsafeMutableBufferPointer),
-    ("test_isUsable", test_isUsable),
     ("test_replacementStorage", test_replacementStorage),
     ("test_deinit", test_deinit),
     ("test_copyingInit", test_copyingInit),

--- a/Tests/PenguinStructuresTests/ArrayStorageTests.swift
+++ b/Tests/PenguinStructuresTests/ArrayStorageTests.swift
@@ -104,7 +104,13 @@ extension ArrayStorage where Element: Equatable {
       XCTAssertEqual(s1.last, source.first)
       
       let s2 = doAppending(source.first!, moveElements: true)
-      XCTAssert(s1.elementsEqual(s2))
+      XCTAssert(
+        s1.elementsEqual(s2),
+        """
+        Expected equality!
+        \(Array(s1))
+        \(Array(s2))
+        """)
     }
   }
 


### PR DESCRIPTION
- Makes construction of empty `Array`[`Buffer`|`Storage`] super-efficient
- Could removes optionality of storage in `AnyArrayBuffer` but for ARC optimizer weakness
- Will allow us to create a zero tensor in type-erased storage (in SwiftFusion) without knowing the element type.

Note that because the dynamic class type of an `AnyArrayStorage` captures aspects of its `Element` type, it becomes important not to expose those derived class instances as extension point if we are aliasing an instance of fake dynamic element type.  Therefore `ArrayStorage<T>` becomes a `struct` in this PR.

589% speedup observed in empty `ArrayStorage` creation.