### PR TITLE
PenguinTesting: add checkDeclaredSequenceRefinementSemantics

### DIFF
--- a/Tests/PenguinStructuresTests/ArrayBufferTests.swift
+++ b/Tests/PenguinStructuresTests/ArrayBufferTests.swift
@@ -154,10 +154,13 @@ class ArrayBufferTests: XCTestCase {
     XCTAssertEqual(trackCount, 0)
   }
 
-  func test_collectionSemantics() {
+func test_collectionSemantics() {
     var b = ArrayBuffer<Int>(0..<100)
-    b.checkRandomAccessCollectionSemantics(expectedValues: 0..<100)
-    b.checkMutableCollectionSemantics(source: 50..<150)
+    b.checkRandomAccessCollectionSemantics(expecting: 0..<100)
+    b.checkMutableCollectionSemantics(writing: 50..<150)
+
+    // Exercise the new tests.
+    b.checkDeclaredSequenceRefinementSemantics(expecting: Array(b))
   }
 
   func test_storageInit() {

--- a/Tests/PenguinStructuresTests/ArrayStorageExtensionTests.swift
+++ b/Tests/PenguinStructuresTests/ArrayStorageExtensionTests.swift
@@ -230,8 +230,8 @@ class ArrayStorageExtensionTests: XCTestCase {
   func test_collectionSemantics() {
     let expected = factoids(0..<35)
     var s = ArrayStorage(expected)
-    s.checkRandomAccessCollectionSemantics(expectedValues: expected)
-    s.checkMutableCollectionSemantics(source: factoids(35..<70))
+    s.checkRandomAccessCollectionSemantics(expecting: expected)
+    s.checkMutableCollectionSemantics(writing: factoids(35..<70))
   }
 
   

--- a/Tests/PenguinStructuresTests/ArrayStorageTests.swift
+++ b/Tests/PenguinStructuresTests/ArrayStorageTests.swift
@@ -263,8 +263,8 @@ class ArrayStorageTests: XCTestCase {
   
   func test_collectionSemantics() {
     var s = ArrayStorage<Int>(0..<100)
-    s.checkRandomAccessCollectionSemantics(expectedValues: 0..<100)
-    s.checkMutableCollectionSemantics(source: 50..<150)
+    s.checkRandomAccessCollectionSemantics(expecting: 0..<100)
+    s.checkMutableCollectionSemantics(writing: 50..<150)
   }
 
   static var allTests = [

--- a/Tests/PenguinStructuresTests/ConcatenationTests.swift
+++ b/Tests/PenguinStructuresTests/ConcatenationTests.swift
@@ -27,74 +27,78 @@ final class ConcatenationTests: XCTestCase {
   }
 
   func testConditionalConformances() {
-    let a3 = 0..<10, b3 = 10..<20, concatenated = 0..<20
+    let a3 = 0..<10, b3 = 10..<20, a3b3 = 0..<20
     let a2 = AnyBidirectionalCollection(a3), b2 = AnyBidirectionalCollection(b3)
     let a1 = AnyCollection(a3), b1 = AnyCollection(b3)
     let j11 = a1.concatenated(to: b1)
     XCTAssertFalse(j11.isBidirectional)
-    j11.checkCollectionSemantics(expectedValues: concatenated)
-
+    j11.checkCollectionSemantics(expecting: a3b3)
+    // Exercising new test facilities
+    j11.checkDeclaredSequenceRefinementSemantics(expecting: a3b3)
+    
     let j12 = a1.concatenated(to: b2)
     XCTAssertFalse(j12.isBidirectional)
-    j12.checkCollectionSemantics(expectedValues: concatenated)
+    j12.checkCollectionSemantics(expecting: a3b3)
 
     let j13 = a1.concatenated(to: b3)
     XCTAssertFalse(j13.isBidirectional)
-    j13.checkCollectionSemantics(expectedValues: concatenated)
+    j13.checkCollectionSemantics(expecting: a3b3)
 
     let j21 = a2.concatenated(to: b1)
     XCTAssertFalse(j21.isBidirectional)
-    j21.checkCollectionSemantics(expectedValues: concatenated)
+    j21.checkCollectionSemantics(expecting: a3b3)
 
     let j22 = a2.concatenated(to: b2)
     XCTAssert(j22.isBidirectional)
     XCTAssertFalse(j22.isRandomAccess)
-    j22.checkBidirectionalCollectionSemantics(expectedValues: concatenated)
+    j22.checkBidirectionalCollectionSemantics(expecting: a3b3)
+    // Exercising new test facilities
+    j22.checkDeclaredSequenceRefinementSemantics(expecting: a3b3)
 
     let j23 = a2.concatenated(to: b3)
     XCTAssert(j23.isBidirectional)
     XCTAssertFalse(j23.isRandomAccess)
-    j23.checkBidirectionalCollectionSemantics(expectedValues: concatenated)
+    j23.checkBidirectionalCollectionSemantics(expecting: a3b3)
 
     let j31 = a3.concatenated(to: b1)
     XCTAssertFalse(j31.isBidirectional)
-    j31.checkCollectionSemantics(expectedValues: concatenated)
+    j31.checkCollectionSemantics(expecting: a3b3)
 
     let j32 = a3.concatenated(to: b2)
     XCTAssert(j32.isBidirectional)
     XCTAssertFalse(j32.isRandomAccess)
-    j32.checkBidirectionalCollectionSemantics(expectedValues: concatenated)
+    j32.checkBidirectionalCollectionSemantics(expecting: a3b3)
 
     let j33 = a3.concatenated(to: b3)
     XCTAssert(j33.isRandomAccess)
-    j33.checkRandomAccessCollectionSemantics(expectedValues: concatenated)
+    j33.checkRandomAccessCollectionSemantics(expecting: a3b3)
   }
 
   func testConcatenateSetToArray() {
     let s = Set(["1", "2", "3"])
     let c = s.concatenated(to: ["10", "11", "12"])
-    c.checkCollectionSemantics(expectedValues: Array(s) + ["10", "11", "12"])
+    c.checkCollectionSemantics(expecting: Array(s) + ["10", "11", "12"])
   }
 
   func testConcatenateRanges() {
     let c = (0..<3).concatenated(to: 3...6)
-    c.checkRandomAccessCollectionSemantics(expectedValues: 0...6)
+    c.checkRandomAccessCollectionSemantics(expecting: 0...6)
   }
 
   func testConcatenateEmptyPrefix() {
     let c = (0..<0).concatenated(to: [1, 2, 3])
-    c.checkRandomAccessCollectionSemantics(expectedValues: 1...3)
+    c.checkRandomAccessCollectionSemantics(expecting: 1...3)
   }
 
   func testConcatenateEmptySuffix() {
     let c = (1...3).concatenated(to: 1000..<1000)
-    c.checkRandomAccessCollectionSemantics(expectedValues: [1, 2, 3])
+    c.checkRandomAccessCollectionSemantics(expecting: [1, 2, 3])
   }
 
   func testMutableCollection() {
     let a = Array(0..<10), b = Array(10..<20)
     var j = a.concatenated(to: b)
-    j.checkMutableCollectionSemantics(source: 20..<40)
+    j.checkMutableCollectionSemantics(writing: 20..<40)
   }
 
   static var allTests = [

--- a/Tests/PenguinStructuresTests/EitherTests.swift
+++ b/Tests/PenguinStructuresTests/EitherTests.swift
@@ -59,6 +59,18 @@ class EitherTests: XCTestCase {
 }
 
 class EitherCollectionTests: XCTestCase {
+  func testSequence() {
+    typealias A = AnySequence<Int>
+    let x = 0...10
+    let y = x.reversed()
+
+    Either<A, A>.a(A(x)).checkSequenceSemantics(expecting: x)
+    Either<A, A>.b(A(y)).checkSequenceSemantics(expecting: y)
+    
+    // Exercising new test facilities
+    Either<A, A>.a(A(x)).checkDeclaredSequenceRefinementSemantics(expecting: x)
+  }
+
   func testCollection() {
     typealias X = ClosedRange<Int>
     typealias Y = ReversedCollection<ClosedRange<Int>>
@@ -66,14 +78,18 @@ class EitherCollectionTests: XCTestCase {
     let y: Y = x.reversed()
 
     // Also tests Sequence semantics
-    Either<X, Y>.a(x).checkCollectionSemantics(expectedValues: x)
-    Either<X, Y>.b(y).checkCollectionSemantics(expectedValues: y)
+    Either<X, Y>.a(x).checkCollectionSemantics(expecting: x)
+    Either<X, Y>.b(y).checkCollectionSemantics(expecting: y)
 
-    Either<Y, X>.b(x).checkCollectionSemantics(expectedValues: x)
-    Either<Y, X>.a(y).checkCollectionSemantics(expectedValues: y)
+    Either<Y, X>.b(x).checkCollectionSemantics(expecting: x)
+    Either<Y, X>.a(y).checkCollectionSemantics(expecting: y)
+
+    // Exercising new test facilities
+    Either<Y, X>.a(y).checkDeclaredSequenceRefinementSemantics(expecting: y)
   }
-
+  
   static var allTests = [
+    ("testSequence", testSequence),
     ("testCollection", testCollection),
   ]
 }

--- a/Tests/PenguinStructuresTests/FixedSizeArrayTests.swift
+++ b/Tests/PenguinStructuresTests/FixedSizeArrayTests.swift
@@ -126,7 +126,7 @@ class FixedSizeArrayTests: XCTestCase {
   }
 
   func test_collectionSemantics() {
-    Array7(0..<7).checkRandomAccessCollectionSemantics(expectedValues: 0..<7)
+    Array7(0..<7).checkRandomAccessCollectionSemantics(expecting: 0..<7)
   }
 
   func test_count() {

--- a/Tests/PenguinStructuresTests/NominalElementDictionaryTests.swift
+++ b/Tests/PenguinStructuresTests/NominalElementDictionaryTests.swift
@@ -43,11 +43,11 @@ final class NominalElementDictionaryTests: XCTestCase {
 
   func test_collectionSemantics() {
     let d = p0
-    let expectedValues = Self.uniqueKeyValues.sorted {
+    let expectedContents = Self.uniqueKeyValues.sorted {
       d.index(forKey: $0.key) ?? d.endIndex
         < d.index(forKey: $1.key) ?? d.endIndex
     }
-    d.checkCollectionSemantics(expectedValues: expectedValues)
+    d.checkCollectionSemantics(expecting: expectedContents)
   }
 
   func test_initFromDictionary() {


### PR DESCRIPTION
Also improve some names.

@marcrasi this should allow you to test those `Scalars` for whatever refined `Collection` semantics they're declared to have.