### PR TITLE
Add AnyValue

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "223d62adc52d51669ae2ee19bdb8b7d9fd6fcd9c",
-          "version": "0.0.6"
+          "revision": "15351c1cd009eba0b6e438bfef55ea9847a8dc4a",
+          "version": "0.3.0"
         }
       },
       {
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/google/swift-benchmark.git",
         "state": {
           "branch": "master",
-          "revision": "4c8bab04c6a0f9e09e4e091d831b146f77842ed9",
+          "revision": "f70bf472b00aeaa05e2374373568c2fe459c11c7",
           "version": null
         }
       }

--- a/Sources/Benchmarks/AnyValueBenchmarks.swift
+++ b/Sources/Benchmarks/AnyValueBenchmarks.swift
@@ -1,0 +1,487 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Benchmark
+import PenguinStructures
+
+// -------------------------------------------------------------------------------------------------
+// Benchmarking Strategy:
+//
+// - Use `AnyValue` as substrate for type-erased `AnyMutableCollection_`.
+// - Also use two other type erasure techniques as substrate.
+// - Benchmark the same operations on the `AnyMutableCollection_` using all 3 substrates.
+// -------------------------------------------------------------------------------------------------
+
+/// Prevents the value of `x` from being discarded by the optimizer.
+///
+/// TODO: when https://github.com/google/swift-benchmark/issues/69 is resolved consider using that
+/// facility instead.
+@inline(__always)
+fileprivate func doNotOptimizeAway<T>(_ x: T) {
+  
+  @_optimize(none) 
+  func assumePointeeIsRead(_ x: UnsafeRawPointer) {}
+  
+  withUnsafePointer(to: x) { assumePointeeIsRead($0) }
+}
+
+/// Returns `x`, preventing its value from being statically known by the optimizer.
+///
+/// TODO: when https://github.com/google/swift-benchmark/issues/74 is resolved consider using that
+/// facility instead.
+@inline(__always)
+fileprivate func hideValue<T>(_ x: T) -> T {
+  
+  @_optimize(none) 
+  func assumePointeeIsWritten<T>(_ x: UnsafeMutablePointer<T>) {}
+  
+  var copy = x
+  withUnsafeMutablePointer(to: &copy) { assumePointeeIsWritten($0) }
+  return copy
+}
+
+//
+// Storage for “vtables” implementing operations on type-erased values.
+//
+// Large tables of Swift functions are expensive if stored inline, and incur ARC and allocation
+// costs if stored in classes.  We want to allocate them once, keep them alive forever, and
+// reference them with cheap unsafe pointers.
+//
+// We therefore need a vtable cache.  For thread-safety, we could share a table and use a lock, but
+// the easiest answer for now is use a thread-local cache per thread.
+typealias TLS = PosixConcurrencyPlatform_.ThreadLocalStorage
+
+/// Holds the lookup table for vtables.  TLS facilities require that this be a class type.
+fileprivate class VTableCache {
+  /// A map from a pair of types (`Wrapper`, `Wrapped`) to the address of a VTable containing the
+  /// implementation of `Wrapper` operations in terms of `Wrapped` operations.
+  var tables: [Array2<TypeID>: UnsafeRawPointer] = [:]
+  init() {}
+}
+
+/// Lookup key for the thread-local vtable cache.
+fileprivate let vTableCacheKey = TLS.makeKey(for: Type<VTableCache>())
+
+/// Constructs a vtable cache instance for the current thread.
+@inline(never)
+fileprivate func makeVTableCache() -> VTableCache {
+  let r = VTableCache()
+  TLS.set(r, for: vTableCacheKey)
+  return r
+}
+
+/// Returns a pointer the table corresponding to `tableID`, creating it by invoking `create` if it
+/// is not already available.
+fileprivate func demandVTable<Table>(_ tableID: Array2<TypeID>, create: ()->Table)
+  -> UnsafePointer<Table>
+{
+  /// Returns a pointer to a globally-allocated copy of the result of `create`, registering it
+  /// in `tableCache`.
+  @inline(never)
+  func makeAndCacheTable(in cache: VTableCache) -> UnsafePointer<Table> {
+    let r = UnsafeMutablePointer<Table>.allocate(capacity: 1)
+    r.initialize(to: create())
+    cache.tables[tableID] = .init(r)
+    return .init(r)
+  }
+  
+  let slowPathCache: VTableCache
+  
+  if let cache = TLS.get(vTableCacheKey) {
+    if let r = cache.tables[tableID] { return r.assumingMemoryBound(to: Table.self) }
+    slowPathCache = cache
+  }
+  else {
+    slowPathCache = makeVTableCache()
+  }
+  return makeAndCacheTable(in: slowPathCache)
+}
+
+/// The API of types that can be used by `AnyMutableCollection_` as type-erased storage substrate.
+///
+/// See the strategy note at the top of this file for details.
+internal protocol AnyValueProtocol {
+  /// Creates an instance that stores `x`.
+  ///
+  /// - Postcondition: where `a` is the created instance, `a.storedType == T.self`, and `a[T.self]`
+  ///   is equivalent to `x`.
+  init<T>(_ x: T)
+  
+  /// The type of the value stored in `self`.
+  var storedType: Any.Type { get }
+
+  /// Accesses the `T` stored in `self`.
+  ///
+  /// - Requires: `storedType == T.self`.
+  subscript<T>(_: Type<T>) -> T { get set }
+
+  /// Unsafely accesses the `T` stored in `self`.
+  ///
+  /// - Requires: `storedType == T.self`.
+  subscript<T>(unsafelyAssuming _: Type<T>) -> T { get set }
+
+  /// Stores `x` in `self`.
+  mutating func store<T>(_ x: T)
+
+  /// The stored value.
+  var asAny: Any { get }
+}
+
+extension AnyValue: AnyValueProtocol {}
+
+/// Type-erased storage substrate based on direct, naïve use of `Any`
+internal struct NaiveAnyBased_AnyValue: AnyValueProtocol {
+  var storage: Any
+  
+  /// Creates an instance that stores `x`.
+  ///
+  /// - Postcondition: where `a` is the created instance, `a.storedType == T.self`, and `a[T.self]`
+  ///   is equivalent to `x`.
+  init<T>(_ x: T) { storage = x }
+  
+  /// The type of the value stored in `self`.
+  var storedType: Any.Type {
+    withUnsafePointer(to: self) {
+      // Okay, this is not exactly naive, but it's the only way to get the right semantics, and it's
+      // more efficient than type(of: storage) so it's fair to the real AnyValue implementation.
+      UnsafeRawPointer($0)
+        .assumingMemoryBound(to: (Int,Int,Int, storedType: Any.Type).self).pointee.storedType
+    }
+  }
+
+  /// Accesses the `T` stored in `self`.
+  ///
+  /// - Requires: `storedType == T.self`.
+  subscript<T>(_: Type<T>) -> T {
+    get { storage as! T }
+    set { storage = newValue }
+  }
+
+  /// Unsafely accesses the `T` stored in `self`.
+  ///
+  /// - Requires: `storedType == T.self`.
+  subscript<T>(unsafelyAssuming _: Type<T>) -> T {
+    get { (storage as? T).unsafelyUnwrapped }
+    set { storage = newValue }
+  }
+  
+  /// Stores `x` in `self`.
+  mutating func store<T>(_ x: T) { storage = x }
+
+  /// The stored value.
+  var asAny: Any { storage }
+}
+
+/// Type-erased storage substrate based on unconditional boxing of stored values into class
+/// instances.
+///
+/// Note that all dispatching in this file uses the “non-capturing closure” technique from the type
+/// erasure survey (https://gist.github.com/dabrahams/c75760b7ed36dd4f039f3679ede825ea), so in no
+/// case do we use methods of those classes to capture behavior.  This is just about storage!
+internal struct ClassBoxBased_AnyValue: AnyValueProtocol {
+  /// A dynamically-allocated box storing a statically-unknown type that doesn't fit in an
+  /// existential's inline buffer.
+  private class BoxBase {
+    /// The type stored in this box.
+    final let storedType: Any.Type
+
+    /// Creates an instance with the given `storedType`
+    fileprivate init(storedType: Any.Type) {
+      self.storedType = storedType
+    }
+
+    /// Returns the boxed value.
+    fileprivate var asAny: Any { fatalError("override me") }
+  }
+
+  /// A box holding a value of type `T`, which wouldn't fit in an existential's inline buffer.
+  ///
+  /// - Note: it's crucial to always cast a `Box` instance to `BoxBase` before assigning it into
+  ///   `storage.`
+  private final class Box<T>: BoxBase {
+    /// The boxed value
+    var value: T
+
+    /// Creates an instance storing `value`
+    ///
+    /// - Requires: !MemoryLayout<T>.fitsExistentialInlineBuffer
+    init(_ value: T) {
+      assert(!(value is BoxBase), "unexpectedly boxing a box!")
+      self.value = value
+      super.init(storedType: T.self)
+    }
+
+    /// Returns the boxed value.
+    fileprivate override var asAny: Any { value }
+  }
+  
+  private var storage: BoxBase
+  
+  /// Creates an instance that stores `x`.
+  ///
+  /// - Postcondition: where `a` is the created instance, `a.storedType == T.self`, and `a[T.self]`
+  ///   is equivalent to `x`.
+  init<T>(_ x: T) { storage = Box(x) }
+  
+  /// The type of the value stored in `self`.
+  var storedType: Any.Type {
+    storage.storedType
+  }
+
+  /// Accesses the `T` stored in `self`.
+  ///
+  /// - Requires: `storedType == T.self`.
+  subscript<T>(_: Type<T>) -> T {
+    get {
+      precondition(storedType == T.self)
+      return unsafeDowncast(storage, to: Box<T>.self).value
+    }
+    _modify {
+      precondition(storedType == T.self)
+      if !isKnownUniquelyReferenced(&storage) {
+        storage = Box(unsafeDowncast(storage, to: Box<T>.self).value)
+      }
+      yield &unsafeDowncast(storage, to: Box<T>.self).value
+    }
+  }
+
+  /// Unsafely accesses the `T` stored in `self`.
+  ///
+  /// - Requires: `storedType == T.self`.
+  subscript<T>(unsafelyAssuming _: Type<T>) -> T {
+    get {
+      return unsafeDowncast(storage, to: Box<T>.self).value
+    }
+    _modify {
+      if !isKnownUniquelyReferenced(&storage) {
+        cloneStorage(Type<T>())
+      }
+      yield &unsafeDowncast(storage, to: Box<T>.self).value
+    }
+  }
+
+  /// Makes the storage uniquely-referenced.
+  @inline(never)
+  mutating func cloneStorage<T>(_: Type<T>) {
+    storage = Box(unsafeDowncast(storage, to: Box<T>.self).value)
+  }
+  
+  /// Stores `x` in `self`.
+  mutating func store<T>(_ x: T) {
+    if storedType == T.self {
+      unsafeDowncast(storage, to: Box<T>.self).value = x
+    }
+    else {
+      storeSlowPath(x)
+    }
+  }
+
+  @inline(never)
+  mutating func storeSlowPath<T>(_ x: T) {
+    storage = Box(x)
+  }
+
+  /// The stored value.
+  var asAny: Any { storage.asAny }
+}
+
+/// A type-erased mutable collection similar to the standard library's `AnyCollection`, but with
+/// parameterized type-erasure substrate.
+fileprivate struct AnyMutableCollection_<Element, Storage: AnyValueProtocol> {
+  var storage: Storage
+  var vtable: UnsafePointer<VTable>
+  
+  typealias Self_ = Self
+  struct VTable {
+    let makeIterator: (Self_) -> Iterator
+    let startIndex: (Self_) -> Index
+    let endIndex: (Self_) -> Index
+    let indexAfter: (Self_, Index) -> Index
+    let formIndexAfter: (Self_, inout Index) -> Void
+    let subscript_get: (Self_, Index) -> Element
+    let subscript_set: (inout Self_, Index, Element) -> Void
+    let count: (Self_) -> Int
+    // There are many more `Collection` requirements with default implementations that would be
+    // optimized if we included them here.
+  }
+  
+  init<C: MutableCollection>(_ x: C) where C.Element == Element {
+    storage = Storage(x)
+    vtable = demandVTable(.init(Type<Self>.id, Type<C>.id)) {
+      VTable(
+        makeIterator: { Iterator($0.storage[unsafelyAssuming: Type<C>()].makeIterator()) },
+        startIndex: { Index($0.storage[unsafelyAssuming: Type<C>()].startIndex) },
+        endIndex: { Index($0.storage[unsafelyAssuming: Type<C>()].endIndex) },
+        indexAfter: { self_, index_ in
+          Index(
+            self_.storage[unsafelyAssuming: Type<C>()]
+              .index(after: index_.storage[Type<C.Index>()]))
+        },
+        formIndexAfter: { self_, index in
+          self_.storage[unsafelyAssuming: Type<C>()]
+            .formIndex(after: &index.storage[Type<C.Index>()])
+        },
+        subscript_get: { self_, index in
+          self_.storage[unsafelyAssuming: Type<C>()][index.storage[Type<C.Index>()]]
+        },
+        subscript_set: { self_, index, newValue in
+          self_.storage[unsafelyAssuming: Type<C>()][index.storage[Type<C.Index>()]] = newValue
+        },
+        count: { $0.storage[unsafelyAssuming: Type<C>()].count })
+    }
+  }
+}
+
+extension AnyMutableCollection_: Sequence {
+  struct Iterator: IteratorProtocol {
+    var storage: Storage
+    // There's only one operation, so probably no point bothering with a vtable.
+    var next_: (inout Self) -> Element?
+
+    init<T: IteratorProtocol>(_ x: T) where T.Element == Element {
+      storage = .init(x)
+      next_ = { $0.storage[unsafelyAssuming: Type<T>()].next() }
+    }
+
+    mutating func next() -> Element? { next_(&self) }
+  }
+
+  func makeIterator() -> Iterator { vtable[0].makeIterator(self) }
+}
+
+extension AnyMutableCollection_: MutableCollection {
+  struct Index: Comparable {
+    var storage: Storage
+    // Note: using a vtable here actually made benchmarks slower.  We might want to try again if we
+    // expand what the benchmarks are doing.  My hunch is that the cost of copying an Index is less
+    // important than the cost of checking for equality.
+    var less: (Index, Index) -> Bool
+    var equal: (Index, Index) -> Bool
+
+    init<T: Comparable>(_ x: T) {
+      storage = .init(x)
+      less = {l, r in l.storage[unsafelyAssuming: Type<T>()] < r.storage[Type<T>()]}
+      equal = {l, r in l.storage[unsafelyAssuming: Type<T>()] == r.storage[Type<T>()]}
+    }
+
+    static func == (lhs: Index, rhs: Index) -> Bool {
+      lhs.equal(lhs, rhs)
+    }
+    
+    static func < (lhs: Index, rhs: Index) -> Bool {
+      lhs.less(lhs, rhs)
+    }
+  }
+
+  var startIndex: Index { vtable[0].startIndex(self) }
+  
+  var endIndex: Index { vtable[0].endIndex(self) }
+  
+  func index(after x: Index) -> Index { vtable[0].indexAfter(self, x) }
+  
+  func formIndex(after x: inout Index) { vtable[0].formIndexAfter(self, &x) }
+  
+  subscript(i: Index) -> Element {
+    get { vtable[0].subscript_get(self, i) }
+    set { vtable[0].subscript_set(&self, i, newValue) }
+  }
+  
+  var count: Int { vtable[0].count(self) }
+}
+
+extension MutableCollection {
+  /// Exchanges the first and second halves of `self`, omitting the last element if `count` is odd.
+  mutating func swapHalves() {
+    let mid = index(startIndex, offsetBy: count / 2)
+    var a = startIndex
+    var b = mid
+    while a != mid && b != endIndex {
+      swapAt(a, b)
+      formIndex(after: &a)
+      formIndex(after: &b)
+    }
+  }
+}
+
+extension AnyValueProtocol {
+  /// A standard set of tests for measuring the performance of type erasure.
+  static var benchmarks: BenchmarkSuite {
+    .init(name: String(describing: self)) { suite in
+
+      func erasedArray(_ n: Int) -> AnyMutableCollection_<Int, Self> {
+        hideValue(.init(Array(0..<n)))
+      }
+      
+      suite.benchmark("erased [Int] sum") { state in
+        let src = erasedArray(1000000)
+        var sum = 0
+        try state.measure {
+          for x in src { sum += x }
+        }
+        doNotOptimizeAway(sum)
+      }
+      
+      suite.benchmark("erased [Int] swapHalves") { state in
+        var target = erasedArray(10000)
+        try state.measure {
+          target.swapHalves()
+        }
+        doNotOptimizeAway(target)
+      }
+      
+      func erasedConcatenatedArrays(_ n: Int) -> AnyMutableCollection_<Int, Self> {
+        hideValue(.init(Array(0..<n).concatenated(to: Array(n..<2*n))))
+      }
+      
+      suite.benchmark("erased [Int]x2 sum") { state in
+        let src = erasedConcatenatedArrays(100000)
+        var sum = 0
+        try state.measure {
+          for x in src { sum += x }
+        }
+        doNotOptimizeAway(sum)
+      }
+      
+      suite.benchmark("erased [Int]x2 swapHalves") { state in
+        var target = erasedConcatenatedArrays(10000)
+        try state.measure {
+          target.swapHalves()
+        }
+        doNotOptimizeAway(target)
+      }
+
+      func doubleErasedArrays(_ n: Int) -> AnyMutableCollection_<Int, Self> {
+        // This has two levels of type erasure.
+        hideValue(.init(erasedConcatenatedArrays(n).concatenated(to: erasedConcatenatedArrays(n))))
+      }
+      
+      suite.benchmark("erased [Int]x4 sum") { state in
+        let src = doubleErasedArrays(1000)
+        var sum = 0
+        try state.measure {
+          for x in src { sum += x }
+        }
+        doNotOptimizeAway(sum)
+      }
+      
+      suite.benchmark("erased [Int]x4 swapHalves") { state in
+        var target = doubleErasedArrays(1000)
+        try state.measure {
+          target.swapHalves()
+        }
+        doNotOptimizeAway(target)
+      }
+    }
+  }
+}

--- a/Sources/Benchmarks/ConcurrencyPlatform.swift
+++ b/Sources/Benchmarks/ConcurrencyPlatform.swift
@@ -1,0 +1,216 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// -------------------------------------------------------------------------------------------------
+// WARNING: temporary duplication of code in PenguinParallel
+// (https://github.com/saeta/penguin/issues/114)
+// -------------------------------------------------------------------------------------------------
+
+import PenguinStructures
+
+/// Abstracts over different concurrency abstractions.
+///
+/// Some environments have different concurrency abstractions, such as fundamental locks, threads
+/// and condition variables. This protocol allows writing code that is generic across the different
+/// concurrency environments.
+///
+/// These abstractions are designed to be relatively minimialistic in order to be easy to port to a
+/// variety of environments. Key environments include: macOS, Linux, Android, Windows, and Google's
+/// internal enviornment.
+internal protocol ConcurrencyPlatform {
+  /// The type of mutexes (aka locks) used.
+  associatedtype Mutex: DefaultInitializable  // : MutexProtocol  // Commented out due to redundant conformance warning.
+  /// The type of conditional mutexes that are available.
+  associatedtype ConditionMutex: ConditionMutexProtocol & DefaultInitializable
+  /// The type of the condition variable that's available.
+  associatedtype ConditionVariable: ConditionVariableProtocol & DefaultInitializable
+  where ConditionVariable.Mutex == Mutex
+  /// The type of threads that are used.
+  associatedtype Thread: ThreadProtocol
+  /// The thread local storage.
+  associatedtype BaseThreadLocalStorage: RawThreadLocalStorage
+  /// A convenient type to manage thread local storage.
+  typealias ThreadLocalStorage = TypedThreadLocalStorage<BaseThreadLocalStorage>
+
+  /// Makes a thread.
+  func makeThread(name: String, _ fn: @escaping () -> Void) -> Thread
+}
+
+/// Represents a thread of execution.
+internal protocol ThreadProtocol {
+  /// Blocks until the thread has finished executing.
+  ///
+  /// If `self` has already finished executing, `join()` returns immediately. It is up to the
+  /// application to signal to the executing thread that it should exit if it will not do so
+  /// otherwise.
+  ///
+  /// This function can be called multiple times.
+  func join()
+}
+
+/// Mutual exclusion locks.
+internal protocol MutexProtocol {
+  // TODO: determine if `lock` and `unlock` should be mutating methods.
+
+  /// Initializes the lock in the unlocked state.
+  init()
+
+  /// Locks the lock
+  func lock()
+
+  /// Unlocks the lock.
+  func unlock()
+}
+
+extension MutexProtocol {
+  /// Runs `fn` while holding `self`'s lock.
+  internal func withLock<T>(_ fn: () throws -> T) rethrows -> T {
+    lock()
+    defer { unlock() }
+    return try fn()
+  }
+}
+
+/// Allows for waiting until a given condition is satisifed.
+internal protocol ConditionMutexProtocol: MutexProtocol {
+
+  /// Locks `self` when `predicate` returns true.
+  ///
+  /// Must be called when `self` is not locked by the current thread of execution.
+  ///
+  /// - Parameter predicate: A function that returns `true` when the lock should be locked by the
+  ///   current thread of execution. `predicate` is only executed while holding the lock.
+  func lockWhen(_ predicate: () -> Bool)
+
+  func lockWhen<T>(_ predicate: () -> Bool, _ body: () throws -> T) rethrows -> T
+
+  /// Unlocks `self` until `predicate` returns `true`.
+  ///
+  /// Must be called when `self` is locked by the current thread of execution.
+  ///
+  /// - Parameter predicate: A function that returns `true` when `self` should be locked by the
+  ///   current thread of execution. `predicate` is only executed while holding the lock.
+  func await(_ predicate: () -> Bool)
+}
+
+extension ConditionMutexProtocol {
+  internal func lockWhen(_ predicate: () -> Bool) {
+    lock()
+    await(predicate)
+  }
+
+  internal func lockWhen<T>(_ predicate: () -> Bool, _ body: () throws -> T) rethrows -> T {
+    lockWhen(predicate)
+    defer { unlock() }
+    return try body()
+  }
+}
+
+/// A condition variable.
+///
+/// Only perform operations on `self` when holding the mutex associated with `self`.
+internal protocol ConditionVariableProtocol {
+  /// The mutex type associated with this condition variable.
+  associatedtype Mutex: MutexProtocol
+
+  /// Initializes `self`.
+  init()
+
+  /// Wait until signaled, releasing `lock` while waiting.
+  ///
+  /// - Precondition: `lock` is locked.
+  /// - Postcondition: `lock` is locked.
+  func wait(_ lock: Mutex)
+
+  /// Wake up one waiter.
+  ///
+  /// - Precondition: the `lock` associated with `self` is locked.
+  func signal()
+
+  /// Wake up all waiters.
+  ///
+  /// - Precondition: the `lock` associated with `self` is locked.
+  func broadcast()
+}
+
+/// Abstracts over thread local storage.
+internal protocol RawThreadLocalStorage {
+  /// The key type used to index into the thread local storage.
+  associatedtype Key
+
+  /// Makes a new key; the returned key should be used for the entire process lifetime.
+  static func makeKey() -> Key
+  /// Retrieves the raw pointer associated with the given key.
+  static func get(for key: Key) -> UnsafeMutableRawPointer?
+  /// Sets the raw pointer associated with the given key.
+  static func set(value: UnsafeMutableRawPointer?, for key: Key)
+}
+
+/// Wrapper around an underlying thread local storage abstraction to provide a
+/// nicer, typed thread local storage interface.
+internal struct TypedThreadLocalStorage<Underlying: RawThreadLocalStorage> {
+
+  /// Token used to index into the thread local storage.
+  internal struct Key<Value: AnyObject> {
+    fileprivate let key: Underlying.Key
+
+    /// The thread-local value associated with `self`.
+    internal var localValue: Value? {
+      get {
+        TypedThreadLocalStorage<Underlying>.get(self)
+      }
+      nonmutating set {
+        TypedThreadLocalStorage<Underlying>.set(newValue, for: self)
+      }
+    }
+  }
+
+  /// Allocates a key for type `T`.
+  internal static func makeKey<T: AnyObject>(for _: Type<T>) -> Key<T> {
+    Key(key: Underlying.makeKey())
+  }
+
+  /// Retrieves the thread-local value for `key`, if it exists.
+  internal static func get<T: AnyObject>(_ key: Key<T>) -> T? {
+    guard let ptr = Underlying.get(for: key.key) else { return nil }
+    return Unmanaged.fromOpaque(ptr).takeUnretainedValue()
+  }
+
+  /// Retrieves the thread-local value for `key`, creating it with `defaultValue` if it has not
+  /// previously been set.
+  internal static func get<T: AnyObject>(
+    _ key: Key<T>,
+    default defaultValue: @autoclosure () -> T
+  ) -> T {
+    if let ptr = Underlying.get(for: key.key) {
+      return Unmanaged.fromOpaque(ptr).takeUnretainedValue()
+    } else {
+      let value = defaultValue()
+      set(value, for: key)
+      return value
+    }
+  }
+
+  /// Stores `newValue` in thread-local storage using `key`.
+  internal static func set<T: AnyObject>(_ newValue: T?, for key: Key<T>) {
+    if let existingValue = get(key) {
+      Unmanaged.passUnretained(existingValue).release()
+    }
+    if let newValue = newValue {
+      Underlying.set(value: Unmanaged.passRetained(newValue).toOpaque(), for: key.key)
+    } else {
+      Underlying.set(value: nil, for: key.key)
+    }
+  }
+}

--- a/Sources/Benchmarks/NonBlockingCondition.swift
+++ b/Sources/Benchmarks/NonBlockingCondition.swift
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// -------------------------------------------------------------------------------------------------
+// WARNING: temporary duplication of code in PenguinParallel
+// (https://github.com/saeta/penguin/issues/114)
+// -------------------------------------------------------------------------------------------------
+
 import Benchmark
 import PenguinParallelWithFoundation
 

--- a/Sources/Benchmarks/NonBlockingThreadPool.swift
+++ b/Sources/Benchmarks/NonBlockingThreadPool.swift
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// -------------------------------------------------------------------------------------------------
+// WARNING: temporary duplication of code in PenguinParallel
+// (https://github.com/saeta/penguin/issues/114)
+// -------------------------------------------------------------------------------------------------
+
 import Benchmark
 import PenguinParallelWithFoundation
 

--- a/Sources/Benchmarks/PosixConcurrencyPlatform.swift
+++ b/Sources/Benchmarks/PosixConcurrencyPlatform.swift
@@ -1,0 +1,173 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// -------------------------------------------------------------------------------------------------
+// WARNING: temporary duplication of code in PenguinParallel
+// (https://github.com/saeta/penguin/issues/114)
+// -------------------------------------------------------------------------------------------------
+
+import Foundation
+import PenguinStructures
+
+#if os(macOS)
+  import Darwin
+#elseif os(Windows)
+  import ucrt
+  import WinSDK
+#else
+  import Glibc
+#endif
+
+internal struct PosixConcurrencyPlatform_: ConcurrencyPlatform, DefaultInitializable {
+  internal init() {}
+  internal typealias Mutex = NSMutex
+  internal typealias ConditionMutex = NSConditionMutex
+  internal typealias ConditionVariable = NSConditionVariable
+  internal typealias Thread = PosixThread
+  internal typealias BaseThreadLocalStorage = PosixThreadLocalStorage
+
+  internal func makeThread(name: String, _ fn: @escaping () -> Void) -> Thread {
+    PosixThread(name: name, fn)
+  }
+}
+
+/// A basic thread implemented on top of POSIX system calls.
+internal class PosixThread: ThreadProtocol, CustomStringConvertible {
+  // thread handle.
+  #if os(Windows)
+    typealias Handle = HANDLE
+    private var handle: Handle = INVALID_HANDLE_VALUE
+  #else
+    #if os(macOS)
+      typealias Handle = pthread_t?
+      private var handle: Handle = nil
+    #else
+      typealias Handle = pthread_t
+      private var handle: Handle = pthread_t()
+    #endif
+  #endif
+
+  private let name: String
+
+  // Closures aren't explicitly ref-counted, so wrap in a class.
+  class BodyHolder {
+    /// Initialize `BodyHolder`.
+    init(_ body: @escaping () -> Void) { self.body = body }
+    /// The body of the thread we should execute.
+    let body: () -> Void
+  }
+
+  /// Creates a new thread with name `name`.
+  init(name: String, _ body: @escaping () -> Void) {
+    self.name = name
+    let bodyHolder = Unmanaged.passRetained(BodyHolder(body)).toOpaque()
+    #if os(Windows)
+      fatalError("IMPLEMENT ME!")
+    #else  // !os(Windows)
+      let status = pthread_create(
+        &self.handle,
+        nil,
+        {
+          #if os(macOS)
+            let bodyHolder: PosixThread.BodyHolder = Unmanaged.fromOpaque($0).takeRetainedValue()
+          #else  // Linux / Android / etc.
+            let bodyHolder: PosixThread.BodyHolder = Unmanaged.fromOpaque($0!).takeRetainedValue()
+          #endif
+          bodyHolder.body()  // Run the thread!
+          return nil  // Must return void*
+        },
+        bodyHolder)
+      precondition(status == 0, "Could not pthread_create!")
+    #endif
+  }
+
+  /// Blocks until the thread represented by `self` terminates.
+  internal func join() {
+    #if os(Windows)
+      fatalError("IMPLEMENT ME!")
+    #else
+      #if os(macOS)
+        precondition(pthread_join(handle!, nil) == 0, "Could not pthread_join")
+      #else
+        precondition(pthread_join(handle, nil) == 0, "Could not pthread_join")
+      #endif
+    #endif
+  }
+
+  /// A string representation of this thread.
+  internal var description: String { "PosixThread(\(name))" }
+}
+
+/// A wrapper around `NSLock` to conform to the `MutexProtocol`.
+///
+/// Note: a wrapper is required in order to satisfy the initialization requirement.
+internal struct NSMutex: MutexProtocol, DefaultInitializable {
+  private var nsLock = NSLock()
+
+  /// Initializes `self` in an unlocked state.
+  internal init() {}
+
+  /// Locks `self`.
+  internal func lock() { nsLock.lock() }
+
+  /// Unlocks `self`.
+  internal func unlock() { nsLock.unlock() }
+}
+
+internal struct NSConditionMutex: ConditionMutexProtocol, DefaultInitializable {
+  var condition = NSCondition()
+  internal init() {}
+  internal func lock() { condition.lock() }
+  internal func unlock() {
+    condition.signal()
+    condition.unlock()
+  }
+  internal func await(_ predicate: () -> Bool) {
+    while !predicate() {
+      condition.signal()  // Signal another waiter to potentially wake up.
+      condition.wait()
+    }
+  }
+}
+
+internal struct NSConditionVariable: ConditionVariableProtocol, DefaultInitializable {
+  internal typealias Mutex = NSMutex
+
+  private var condition = NSCondition()
+
+  /// Initializes an empty condition variable.
+  internal init() {}
+
+  internal func wait(_ lock: NSMutex) {
+    // Lock priorities: lock > condition.
+    condition.lock()
+    lock.unlock()
+    condition.wait()
+    condition.unlock()
+    lock.lock()
+  }
+
+  internal func signal() {
+    // we must lock here before we signal in order to avoid a race condition with waiters.
+    condition.lock()
+    condition.signal()
+    condition.unlock()
+  }
+
+  internal func broadcast() {
+    condition.lock()
+    condition.broadcast()
+    condition.unlock()
+  }
+}

--- a/Sources/Benchmarks/ThreadLocalStorage.swift
+++ b/Sources/Benchmarks/ThreadLocalStorage.swift
@@ -1,0 +1,74 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// -------------------------------------------------------------------------------------------------
+// WARNING: temporary duplication of code in PenguinParallel
+// (https://github.com/saeta/penguin/issues/114)
+// -------------------------------------------------------------------------------------------------
+
+#if os(macOS)
+  import Darwin
+#elseif os(Windows)
+  import ucrt
+  import WinSDK
+#else
+  import Glibc
+#endif
+
+internal struct PosixThreadLocalStorage: RawThreadLocalStorage {
+  #if os(macOS)
+    /// A function to delete the raw memory.
+    typealias KeyDestructor = @convention(c) (UnsafeMutableRawPointer) -> Void
+    private static let keyDestructor: KeyDestructor = {
+      Unmanaged<AnyObject>.fromOpaque($0).release()
+    }
+  #else
+    /// A function to delete the raw memory.
+    typealias KeyDestructor = @convention(c) (UnsafeMutableRawPointer?) -> Void
+    private static let keyDestructor: KeyDestructor = {
+      if let obj = $0 {
+        Unmanaged<AnyObject>.fromOpaque(obj).release()
+      }
+    }
+  #endif
+
+  public struct Key {
+    #if os(Windows)
+      var value: DWORD
+    #else
+      var value: pthread_key_t
+    #endif
+
+    init() {
+      #if os(Windows)
+        fatalError("Unimplemented!")
+      #else
+        value = pthread_key_t()
+        pthread_key_create(&value, keyDestructor)
+      #endif
+    }
+  }
+
+  public static func makeKey() -> Key {
+    Key()
+  }
+
+  public static func get(for key: Key) -> UnsafeMutableRawPointer? {
+    pthread_getspecific(key.value)
+  }
+
+  public static func set(value: UnsafeMutableRawPointer?, for key: Key) {
+    pthread_setspecific(key.value, value)
+  }
+}

--- a/Sources/PenguinStructures/AnyValue.swift
+++ b/Sources/PenguinStructures/AnyValue.swift
@@ -1,0 +1,244 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fileprivate extension MemoryLayout {
+  /// True iff `T` instances are stored in an existential's inline buffer space.
+  static var fitsExistentialInlineBuffer: Bool {
+    MemoryLayout<(T, Any.Type)>.size <= MemoryLayout<Any>.size
+      && self.alignment <= MemoryLayout<Any>.alignment
+      && _isBitwiseTakable(T.self)
+  }
+}
+
+/// A wrapper for a value of any type, with efficient access and inline storage of bounded size for
+/// small values.
+///
+/// Existential types such as `Any` provide the storage characteristics of `AnyValue`, but many
+/// operations on existentials [optimize poorly](https://bugs.swift.org/browse/SR-13438), so
+/// `AnyValue` may be needed to achieve efficient access.
+///
+/// Using `enums` and no existential, it is possible to build such storage for:
+/// - types that are trivially copiable (such as Int), or
+/// - collections of elements with the inline storage being (roughly) a multiple of the element
+///   size.
+/// You might consider using the `enum` approach where applicable.
+public struct AnyValue {
+  /// The memory layout of `Any` instances.
+  private typealias AnyLayout = (inlineStorage: (Int, Int, Int), storedType: Any.Type)
+
+  /// The underlying storage of the value.
+  ///
+  /// Types that fit the inline storage of `Any` are stored directly, by assignment. Although `Any`
+  /// has its own boxing mechanism for types that don't fit its inline storage, it is apparently
+  /// incompatible with our needs for mutation (https://bugs.swift.org/browse/SR-13460) and
+  /// seem to be needlessly reallocated in some cases.  Therefore, larger types are stored
+  /// indirectly in a class instance of static type `BoxBase`. Object references fit the inline
+  /// storage of `Any`, so the value held *directly* by `storage` is always stored in its inline
+  /// buffer.
+  fileprivate var storage: Any
+
+  /// Creates an instance that stores `x`.
+  ///
+  /// - Postcondition: where `a` is the created instance, `a.storedType == T.self`, and `a[T.self]`
+  ///   is equivalent to `x`.
+  public init<T>(_ x: T) {
+    if MemoryLayout<T>.fitsExistentialInlineBuffer { storage = x}
+    else { storage = Box(x) as BoxBase }
+  }
+
+  /// The type of the value held directly by `storage`.
+  ///
+  /// If the type stored in `self` does not fit the inline storage of an existential,
+  /// `directlyStoredType` will be `BoxBase.self`.
+  private var directlyStoredType: Any.Type {    
+    // Note: using withUnsafePointer(to: storage) rather than withUnsafePointer(to: self) produces a
+    // copy of storage, and thus much worse code (https://bugs.swift.org/browse/SR-13462).
+    return Swift.withUnsafePointer(to: self) { // https://bugs.swift.org/browse/SR-13462
+      UnsafeRawPointer($0).assumingMemoryBound(to: AnyLayout.self)[0].storedType
+    }
+  }
+
+  /// The type of the value stored in `self`.
+  public var storedType: Any.Type {
+    let d = directlyStoredType
+    if d != Self.boxType { return d }
+    return self[unsafelyAssuming: Type<BoxBase>()].storedType
+  }
+
+  /// Returns a pointer to the `T` which is assumed to be stored in `self`.
+  private func pointer<T>(toStored _: Type<T>) -> UnsafePointer<T> {
+    // Note: using withUnsafePointer(to: storage) rather than withUnsafePointer(to: self) produces a
+    // copy of storage, and thus much worse code (https://bugs.swift.org/browse/SR-13462).
+    return withUnsafePointer(to: self) {
+      let address = UnsafeRawPointer($0)
+      if MemoryLayout<T>.fitsExistentialInlineBuffer {
+        return address.assumingMemoryBound(to: T.self)
+      }
+      else {
+        let boxBase = address.assumingMemoryBound(to: Self.boxType).pointee
+        let box = unsafeDowncast(boxBase, to: Box<T>.self)
+        return withUnsafeMutablePointer(to: &box.value) { .init($0) }
+      }
+    }
+  }
+
+  /// A dynamically-allocated box storing a statically-unknown type that doesn't fit in an
+  /// existential's inline buffer.
+  private class BoxBase {
+    /// The type stored in this box.
+    final let storedType: Any.Type
+
+    /// Creates an instance with the given `storedType`
+    fileprivate init(storedType: Any.Type) {
+      self.storedType = storedType
+    }
+
+    /// Returns the boxed value.
+    fileprivate var asAny: Any { fatalError("override me") }
+  }
+
+  /// Cached type metadata (see https://bugs.swift.org/browse/SR-13459)
+  private static let boxType = BoxBase.self
+
+  /// A box holding a value of type `T`, which wouldn't fit in an existential's inline buffer.
+  ///
+  /// - Note: it's crucial to always cast a `Box` instance to `BoxBase` before assigning it into
+  ///   `storage.`
+  private final class Box<T>: BoxBase {
+    /// The boxed value
+    var value: T
+
+    /// Creates an instance storing `value`
+    ///
+    /// - Requires: !MemoryLayout<T>.fitsExistentialInlineBuffer
+    init(_ value: T) {
+      assert(
+        !MemoryLayout<T>.fitsExistentialInlineBuffer, "Boxing a value that should be stored inline")
+      assert(!(value is BoxBase), "unexpectedly boxing a box!")
+      self.value = value
+      super.init(storedType: T.self)
+    }
+
+    /// Returns the boxed value.
+    fileprivate override var asAny: Any { value }
+  }
+  
+  /// Returns a pointer to the `T` which is assumed to be stored in `self`.
+  ///
+  /// If the `T` is stored in a shared box, the box is first copied to make it unique.
+  ///
+  /// - Requires: `storedType == T.self`
+  private mutating func mutablePointer<T>(toStored _: Type<T>) -> UnsafeMutablePointer<T> {
+    let address: UnsafeMutableRawPointer = withUnsafeMutablePointer(to: &storage) { .init($0) }
+    if MemoryLayout<T>.fitsExistentialInlineBuffer {
+      return address.assumingMemoryBound(to: T.self)
+    }
+    if !isKnownUniquelyReferenced(&self[unsafelyAssuming: Type<BoxBase>()]) {
+      rebox(stored: Type<T>())
+    }
+    let boxBase = address.assumingMemoryBound(to: Self.boxType).pointee
+    let box = unsafeDowncast(boxBase, to: Box<T>.self)
+    return withUnsafeMutablePointer(to: &box.value) { $0 }
+  }
+
+  /// Copies the boxed `T`.
+  ///
+  /// - Requires: `storedType == T.self`
+  /// - Requires: `!MemoryLayout<T>.fitsExistentialInlineBuffer`
+  // TODO: see if this is really best done out-of-line, considering that `isKnownUniquelyReferenced`
+  // is already a function call.
+  @inline(never)
+  private mutating func rebox<T>(stored _: Type<T>) {
+    storage = Box(self[unsafelyAssuming: Type<T>()]) as BoxBase
+  }
+
+  /// Iff `storedType != T.self`, traps with an appropriate error message.
+  private func typeCheck<T>(_: Type<T>) {
+    if storedType != T.self { typeCheckFailure(T.self) }
+  }
+
+  /// Traps with an appropriate error message assuming that `storedType != T.self`.
+  @inline(never)
+  private func typeCheckFailure(_ expectedType: Any.Type) {
+    fatalError("stored type \(storedType) != \(expectedType)")
+  }
+
+  /// Accesses the `T` stored in `self`.
+  ///
+  /// - Requires: `storedType == T.self`.
+  @inline(__always) // Compiler likes to skip inlining this otherwise.
+  public subscript<T>(_: Type<T>) -> T {
+    get {
+      defer { _fixLifetime(self) }
+      typeCheck(Type<T>())
+      return pointer(toStored: Type<T>()).pointee
+    }
+    _modify {
+      typeCheck(Type<T>())
+      yield &mutablePointer(toStored: Type<T>()).pointee
+      _fixLifetime(self)
+    }
+  }
+
+  /// Unsafely accesses the `T` stored in `self`.
+  ///
+  /// - Requires: `storedType == T.self`.
+  @inline(__always) // Compiler likes to skip inlining this otherwise.
+  public subscript<T>(unsafelyAssuming _: Type<T>) -> T {
+    get {
+      defer { _fixLifetime(self) }
+      return pointer(toStored: Type<T>()).pointee
+    }
+    _modify {
+      yield &mutablePointer(toStored: Type<T>()).pointee
+      _fixLifetime(self)
+    }
+  }
+
+  /// Stores `x` in `self`.
+  ///
+  /// This may be more efficient than `self = AnyValue(x)` because it uses the same allocated buffer
+  /// when possible for large types.
+  public mutating func store<T>(_ x: T) {
+    defer { _fixLifetime(self) }
+    if storedType == T.self { mutablePointer(toStored: Type<T>()).pointee = x }
+    else { self = .init(x) }
+  }
+
+  /// The stored value.
+  ///
+  /// This property can be useful for interoperability with the rest of Swift, especially when you
+  /// don't know the full dynamic type of the stored value.
+  public var asAny: Any {
+    if directlyStoredType != Self.boxType { return storage }
+    return self[unsafelyAssuming: Type<BoxBase>()].asAny
+  }
+
+  /// If the stored value is boxed or is an object, returns the ID of the box or object; returns
+  /// `nil` otherwise.
+  ///
+  /// Used only by tests.
+  internal var boxOrObjectID_testable: ObjectIdentifier? {
+    if !(directlyStoredType is AnyObject.Type) { return nil }
+    return .init(self[unsafelyAssuming: Type<AnyObject>()])
+  }
+}
+
+extension AnyValue: CustomStringConvertible, CustomDebugStringConvertible {
+  /// A textual representation of this instance.
+  public var description: String { String(describing: storage) }
+
+  /// A string, suitable for debugging, that represents the instance.
+  public var debugDescription: String { "AnyValue(\(String(reflecting: storage)))" }
+}

--- a/Tests/PenguinStructuresTests/AnyValueTestable.swift
+++ b/Tests/PenguinStructuresTests/AnyValueTestable.swift
@@ -12,17 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Benchmark
-import PenguinStructures
+// This file is separate from AnyValueTests.swift to ensure that we only use the public API in that
+// file.
+@testable import PenguinStructures
 
-Benchmark.main(
-  [
-    AnyValue.benchmarks,
-    NaiveAnyBased_AnyValue.benchmarks,
-    ClassBoxBased_AnyValue.benchmarks,
-    arrayStorage,
-    nonBlockingCondition,
-    nonBlockingThreadPool,
-    adjacencyList,
-    parallelExpander,
-  ])
+extension AnyValue {
+  internal var boxOrObjectID: ObjectIdentifier? { boxOrObjectID_testable }
+}

--- a/Tests/PenguinStructuresTests/AnyValueTests.swift
+++ b/Tests/PenguinStructuresTests/AnyValueTests.swift
@@ -1,0 +1,199 @@
+// Copyright 2020 Penguin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PenguinTesting
+import PenguinStructures
+import XCTest
+
+fileprivate protocol P {}
+extension Double: P {}
+
+fileprivate class Base {}
+fileprivate class Derived: Base {}
+
+final class AnyValueTests: XCTestCase {
+  // A type that will not fit in existential inline storage.
+  typealias BufferOverflow = (Int, Int, Int, Int)
+
+  // A value that will not fit in existential inline storage.
+  let bufferOverflow = (1, 2, 3, 4)
+  
+  func test_Int() {
+    var a = AnyValue(3)
+    XCTAssert(a.storedType == Int.self)
+    XCTAssertEqual(a[Type<Int>()], 3)
+    XCTAssertEqual(a[unsafelyAssuming: Type<Int>()], 3)
+    
+    a[Type<Int>()] += 1
+    XCTAssertEqual(a[Type<Int>()], 4)
+    XCTAssertEqual(a.boxOrObjectID, nil)
+    
+    a[unsafelyAssuming: Type<Int>()] += 1
+    XCTAssertEqual(a[Type<Int>()], 5)
+  }
+  
+  func test_String() {
+    var a = AnyValue("Three")
+    XCTAssert(a.storedType == String.self)
+    XCTAssertEqual(a[Type<String>()], "Three")
+    XCTAssertEqual(a[unsafelyAssuming: Type<String>()], "Three")
+
+    a[Type<String>()].append("D")
+    XCTAssertEqual(a[Type<String>()], "ThreeD")
+
+    // I don't know how big String is off the top of my head.
+    let inlineStorageExpected = MemoryLayout<String>.size < 3 * MemoryLayout<Int>.size
+      && MemoryLayout<String>.alignment <= MemoryLayout<Any>.alignment
+    
+    if inlineStorageExpected {
+      XCTAssertNil(a.boxOrObjectID)
+    } else {
+      XCTAssertNotNil(a.boxOrObjectID)
+    }
+  }
+
+  func test_BufferOverflow() {
+    var a = AnyValue(bufferOverflow)
+    XCTAssert(a.storedType == type(of: bufferOverflow))
+    XCTAssert(a[Type<BufferOverflow>()] == bufferOverflow)
+    XCTAssert(a[unsafelyAssuming: Type<BufferOverflow>()] == bufferOverflow)
+    
+    let boxID = a.boxOrObjectID
+    XCTAssertNotNil(boxID)
+    
+    a[Type<BufferOverflow>()].0 += 42
+    XCTAssert(a[Type<BufferOverflow>()] == (43, 2, 3, 4))
+    XCTAssertEqual(a.boxOrObjectID, boxID, "Unexpected reallocation of box")
+  }
+
+  func test_class() {
+    let base = Base()
+    var a = AnyValue(base)
+    XCTAssert(a.storedType == type(of: base))
+    XCTAssert(a[Type<Base>()] === base)
+    XCTAssert(a[unsafelyAssuming: Type<Base>()] === base)
+    XCTAssertEqual(a.boxOrObjectID, ObjectIdentifier(base))
+    
+    let otherBase = Base()
+    XCTAssert(otherBase !== base)
+    a[Type<Base>()] = otherBase
+    XCTAssert(a[Type<Base>()] === otherBase)
+    XCTAssertEqual(a.boxOrObjectID, ObjectIdentifier(otherBase))
+  }
+  
+  func testUpcastedSource() {
+    // test postconditions storing a derived class instance as base.
+    let derived = Derived() as Base
+    var a = AnyValue(derived)
+    XCTAssert(a.storedType == Base.self)
+    XCTAssert(a[Type<Base>()] === derived)
+
+    // test postconditions when storing an existential.
+    a = AnyValue(Double.pi as P)
+    XCTAssert(a.storedType == P.self)
+    XCTAssertEqual(a[Type<P>()] as? Double, .pi)
+  }
+
+  func test_store() {
+    var a = AnyValue(3)
+    XCTAssertEqual(a.boxOrObjectID, nil)
+    a.store(4)
+    XCTAssertEqual(a[Type<Int>()], 4, "store didn't update the stored int")
+    XCTAssertEqual(a.boxOrObjectID, nil)
+    
+    var bufferOverflow = self.bufferOverflow
+    a.store(bufferOverflow)
+    let boxID = a.boxOrObjectID
+    XCTAssertNotEqual(boxID, nil, "BufferOverflow is too big, but apparently is stored inline.")
+    XCTAssert(
+      a[Type<BufferOverflow>()] == bufferOverflow, "store didn't update stored BufferOverflow")
+
+    bufferOverflow.0 += 43
+    a.store(bufferOverflow)
+    XCTAssert(
+      a[Type<BufferOverflow>()] == bufferOverflow,
+      "store didn't correctly update stored BufferOverflow")
+    
+    XCTAssertEqual(a.boxOrObjectID, boxID, "store didn't reuse the box")
+    let b = a
+    XCTAssertEqual(
+      b.boxOrObjectID, a.boxOrObjectID,
+      "copies of boxed values unexpectedly don't share a box using CoW")
+    a = AnyValue(bufferOverflow)
+    XCTAssertNotEqual(
+      a.boxOrObjectID, boxID,
+      "Using store is no better than assigning over it with a new Any?")
+    withExtendedLifetime(b) {}
+  }
+
+  func staticType<T>(of _: T) -> Any.Type { T.self }
+  
+  func test_asAny() {
+    var a = AnyValue(3)
+    let aInt = a.asAny
+    XCTAssert(staticType(of: aInt) == Any.self)
+    XCTAssertEqual(aInt as? Int, 3)
+
+    a.store(bufferOverflow)
+    let aBufferOverflow = a.asAny
+    XCTAssert(aBufferOverflow is BufferOverflow)
+    if aBufferOverflow is BufferOverflow {
+      XCTAssert(aBufferOverflow as! BufferOverflow == bufferOverflow)
+    }
+
+    let base = Base()
+    a.store(base)
+    let aBase = a.asAny
+    XCTAssert(aBase as? Base === base)
+  }
+
+  func test_inlineValueSemantics() {
+    var a = AnyValue(3)
+    var b = a
+    a[Type<Int>()] += 1
+    XCTAssertEqual(a[Type<Int>()], 4)
+    XCTAssertEqual(b[Type<Int>()], 3, "value semantics of stored Int not preserved by subscript.")
+    b = a
+    a.store(9)
+    XCTAssertEqual(a[Type<Int>()], 9)
+    XCTAssertEqual(b[Type<Int>()], 4, "value semantics of stored Int not preserved by store()")
+  }
+
+  func test_boxedValueSemantics() {
+    var a = AnyValue(bufferOverflow)
+    var b = a
+    a[Type<BufferOverflow>()].0 += 41
+    XCTAssertEqual(a[Type<BufferOverflow>()].0, 42)
+    XCTAssertEqual(
+      b[Type<BufferOverflow>()].0, 1, "value semantics of boxed value not preserved by subscript.")
+    b = a
+    a.store((4, 3, 2, 1))
+    XCTAssert(a[Type<BufferOverflow>()] == (4, 3, 2, 1))
+    XCTAssert(
+      b[Type<BufferOverflow>()] == (42, 2, 3, 4),
+      "value semantics of boxed value not preserved by store()")
+  }
+
+  static let allTests = [
+    ("test_Int", test_Int),
+    ("test_String", test_String),
+    ("test_BufferOverflow", test_BufferOverflow),
+    ("test_class", test_class),
+    ("testUpcastedSource", testUpcastedSource),
+    ("test_store", test_store),
+    ("test_asAny", test_asAny),
+    ("test_inlineValueSemantics", test_inlineValueSemantics),
+    ("test_boxedValueSemantics", test_boxedValueSemantics),
+  ]
+}

--- a/Tests/PenguinStructuresTests/FactoryInitializableTests.swift
+++ b/Tests/PenguinStructuresTests/FactoryInitializableTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 @testable import PenguinStructures
 
-public class Base : FactoryInitializable {
+fileprivate class Base : FactoryInitializable {
   /// Constructs an instance whose dynamic type depends on the value of `one`.
   public convenience init(optimallyBeDerived1 one: Bool) {
     self.init(unsafelyAliasing: one ? Derived1() : Derived2())
@@ -28,11 +28,11 @@ public class Base : FactoryInitializable {
   }
 }
 
-internal class Derived1 : Base {
+fileprivate class Derived1 : Base {
   override public init() { super.init() }
 }
 
-internal class Derived2 : Base {
+fileprivate class Derived2 : Base {
   override public init() { super.init() }
 }
 

--- a/Tests/PenguinStructuresTests/XCTestManifests.swift
+++ b/Tests/PenguinStructuresTests/XCTestManifests.swift
@@ -19,6 +19,7 @@ import XCTest
     return [
       // Please maintain this list in alphabetical order.
       testCase(AnyArrayBufferTests.allTests),
+      testCase(AnyValueTests.allTests),
       testCase(ArrayBufferTests.allTests),
       testCase(ArrayStorageExtensionTests.allTests),
       testCase(ArrayStorageTests.allTests),


### PR DESCRIPTION
OMG this was so hard to get right, you don't even know.

Note: see commit messages for progression of results.

```
swift run -c release -Xswiftc -cross-module-optimization Benchmarks --warmup-iterations 2 --filter AnyValue

name                                             time            std        iterations warmup      
---------------------------------------------------------------------------------------------------
AnyValue.erased [Int] sum                             6695608 ns ±   3.24 %        210  15740437 ns
AnyValue.erased [Int] swapHalves                      1591548 ns ±   6.03 %        858   3213536 ns
AnyValue.erased [Int]x2 sum                       3812041.500 ns ±   4.37 %        362   7813602 ns
AnyValue.erased [Int]x2 swapHalves                5092725.500 ns ±   4.47 %        266  10145487 ns
AnyValue.erased [Int]x4 sum                           2194474 ns ±   5.67 %        621   4470787 ns
AnyValue.erased [Int]x4 swapHalves                    4961560 ns ±   4.33 %        277  10111853 ns

NaiveAnyBased_AnyValue.erased [Int] sum          68659456.500 ns ±   3.19 %         20 136630376 ns
NaiveAnyBased_AnyValue.erased [Int] swapHalves   26975835.500 ns ±   2.23 %         52  55485238 ns
NaiveAnyBased_AnyValue.erased [Int]x2 sum        34115200.500 ns ±   7.83 %         42  68211571 ns
NaiveAnyBased_AnyValue.erased [Int]x2 swapHalves     61322458 ns ±   1.30 %         22 140975636 ns
NaiveAnyBased_AnyValue.erased [Int]x4 sum         4852811.500 ns ±   3.87 %        290   9933364 ns
NaiveAnyBased_AnyValue.erased [Int]x4 swapHalves 13151125.500 ns ±   4.09 %        104  27471499 ns

ClassBoxBased_AnyValue.erased [Int] sum              13703008 ns ±   7.85 %        101  27719254 ns
ClassBoxBased_AnyValue.erased [Int] swapHalves        2559842 ns ±   4.72 %        532   5151679 ns
ClassBoxBased_AnyValue.erased [Int]x2 sum             2732989 ns ±   4.55 %        508   5658913 ns
ClassBoxBased_AnyValue.erased [Int]x2 swapHalves      5792227 ns ±   3.56 %        242  11931203 ns
ClassBoxBased_AnyValue.erased [Int]x4 sum         2489451.500 ns ±   4.67 %        564   5249983 ns
ClassBoxBased_AnyValue.erased [Int]x4 swapHalves      4859068 ns ±   4.80 %        285   9724080 ns
```