### PR TITLE
make swift-benchmark dependency use version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/google/swift-benchmark.git", .branch("f70bf472b00aeaa05e2374373568c2fe459c11c7")),
+        .package(url: "https://github.com/google/swift-benchmark.git", from: "0.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
This should make it possible to build packages that depend on multiple packages that depend on different version ranges of swift-benchmark (as long as there is at least one compatible version).