### PR TITLE
workaround compile crash

### DIFF
--- a/Sources/PenguinStructures/AnyValue.swift
+++ b/Sources/PenguinStructures/AnyValue.swift
@@ -88,7 +88,7 @@ public struct AnyValue {
       else {
         let boxBase = address.assumingMemoryBound(to: Self.boxType).pointee
         let box = unsafeDowncast(boxBase, to: Box<T>.self)
-        return withUnsafeMutablePointer(to: &box.value) { .init($0) }
+        return box.valuePointerWorkaround
       }
     }
   }
@@ -132,6 +132,14 @@ public struct AnyValue {
 
     /// Returns the boxed value.
     fileprivate override var asAny: Any { value }
+
+    /// Returns a pointer to `value`.
+    // TODO(#131): This works around a compiler crash. Remove this workaround after the crash is
+    // fixed.
+    @inline(never)
+    fileprivate var valuePointerWorkaround: UnsafePointer<T> {
+      withUnsafeMutablePointer(to: &value) { .init($0) }
+    }
   }
   
   /// Returns a pointer to the `T` which is assumed to be stored in `self`.


### PR DESCRIPTION
See #131 for description of the crash.

This can probably be reduced into a simple crasher that can be filed against the Swift compiler, but I haven't tried because I don't know much about what this code is doing and what parts are likely to be triggering this problem.

I ran the AnyValue benchmarks (using the tensorflow-0.11 toolchain) on master vs this PR:
```
                                                 master                                         this pr
name                                             time       std        iterations               time       std        iterations
--------------------------------------------------------------------------------------------------------------------------------
AnyValue.erased [Int] sum                         62.507 ms ±   0.23 %         22                61.576 ms ±   0.20 %         23
AnyValue.erased [Int] swapHalves                  10.079 ms ±   0.49 %        139                 9.966 ms ±   0.48 %        140
AnyValue.erased [Int]x2 sum                       75.865 ms ±   0.21 %         18                76.208 ms ±   0.28 %         18
AnyValue.erased [Int]x2 swapHalves                31.618 ms ±   0.20 %         44                31.599 ms ±   0.31 %         44
AnyValue.erased [Int]x4 sum                        8.586 ms ±   0.41 %        161                 8.660 ms ±   0.58 %        160
AnyValue.erased [Int]x4 swapHalves                19.995 ms ±   0.64 %         70                20.029 ms ±   0.34 %         69
```