### PR TITLE
Upcasting Array buffers now preserves the dispatcher.

### DIFF
--- a/Sources/PenguinStructures/AnyArrayBuffer.swift
+++ b/Sources/PenguinStructures/AnyArrayBuffer.swift
@@ -22,7 +22,7 @@ extension AnyArrayBuffer where Dispatch == AnyObject {
   /// Creates an instance containing the same elements as `src`.
   public init<OtherDispatch>(_ src: AnyArrayBuffer<OtherDispatch>) {
     self.storage = src.storage
-    self.dispatch = Void.self as AnyObject
+    self.dispatch = src.dispatch
   }
 }
 

--- a/Tests/PenguinStructuresTests/ArrayStorageExtensionTests.swift
+++ b/Tests/PenguinStructuresTests/ArrayStorageExtensionTests.swift
@@ -274,6 +274,10 @@ class ArrayStorageExtensionTests: XCTestCase {
 
     let b0a = AnyArrayBuffer<FactoidArrayDispatch>(b0)
     XCTAssert(b0a == nil)
+
+    // Ensure that upcasting dispatch capabilities does not lose the dispatcher's dynamic identity.
+    let upcasted = AnyElementArrayBuffer(b0)
+    XCTAssertEqual(ObjectIdentifier(upcasted.dispatch), ObjectIdentifier(b0.dispatch))
     
     let b1 = AnyArrayBuffer<FactoidArrayDispatch>(ArrayBuffer(factoids(0..<10)))
     XCTAssertEqual(b1.popularity, 35)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saeta/penguin/140)
<!-- Reviewable:end -->
