### PR TITLE
Disable KeyPathIterable

### DIFF
--- a/Sources/PenguinTables/TableSchema.swift
+++ b/Sources/PenguinTables/TableSchema.swift
@@ -15,7 +15,10 @@
 // Some functionality in this file is available only when using a S4TF toolchain, as it depends on
 // S4TF features that haven't yet been merged upstream (e.g. KeyPathIterable). As a result, we gate
 // compilation on whether TensorFlow can be imported.
-#if canImport(TensorFlow)
+//
+// UPDATE(2021-01-29): Given S4TF's move to stock toolchains, we disable KeyPathIterable impls.
+// TODO(2021-01-29): Switch to using reflection instead of KeyPathIterable.
+#if false && canImport(TensorFlow)
 
   public protocol PTableSchema: KeyPathIterable, PDefaultInit {
     var keyPathsToMemberNames: [PartialKeyPath<Self>: String] { get }


### PR DESCRIPTION
Previously, PenguinTable's TableSchema conditionally depended upon
`KeyPathIterable` to automatically implement some functionality.

After S4TF 0.12, S4TF moved to a different implementation of KeyPathIterable,
and as a result, KeyPathIterable is no longer included in the standard library.
This causes compilation errors in Penguin.

This change disables the conditional use of KeyPathIterable and future work can
refactor the implementation to use the new S4TF-contributed reflection APIs.

Fixes: #142.